### PR TITLE
fix(packaging): ship a PEP 561 py.typed marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Type information was not exposed to users.** The package is fully
+  annotated and passes `mypy --strict` on all 133 source files, but shipped no
+  PEP 561 `py.typed` marker, so type checkers and editors in downstream
+  projects silently ignored every annotation and treated `pylinkage` as
+  untyped. The marker is now included in the wheel; no packaging change was
+  needed, since `[tool.hatch.build.targets.wheel]` already covers the whole
+  package directory.
+
 - **Broken examples on the PyPI landing page.** Both README visualization
   snippets called `plot_kinematic_linkage(linkage)`, but that function takes
   `(linkage, fig, axis, loci)` and always has — the signature is identical in


### PR DESCRIPTION
Closes the type-stub half of #24. The benchmarks half is split out into #27.

## What was wrong

`pyproject.toml` already sets `strict = true`, and `uv run task typecheck`
reports *Success: no issues found in 133 source files*. So there were no
annotation gaps left to close — but that green checkmark was hiding a real
bug.

The package shipped no PEP 561 `py.typed` marker. Under PEP 561, a type
checker will not read inline annotations from an installed package without
that marker, so downstream users resolved every `pylinkage` symbol as `Any`.
All of the strictness benefited only this repository and never its users.

## Verification

Built a wheel, installed it into a clean virtualenv, and checked a consumer
module both with and without the marker:

| State | `reveal_type(Ground(0.0, 0.0).x)` |
|---|---|
| Without `py.typed` (pre-fix) | `Any` |
| With `py.typed` (fixed) | `float \| None` |

Confirmed the marker lands in the built wheel as `pylinkage/py.typed`.

No packaging change was required: `[tool.hatch.build.targets.wheel]` sets
`packages = ["src/pylinkage"]`, which already covers every file in the package
directory.

## Checks

- `uv run task lint` — all checks passed
- `uv run task typecheck` — no issues in 133 source files
- `uv run pytest` — 2448 passed, 5 skipped