### PR TITLE
docs(benchmarks): publish reproducible figures for the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Public benchmarks.** `docs/source/benchmarks.md` reports figures for the
+  numba solver, PSO throughput, and the three synthesis entry points, together
+  with the hardware they came from and the command that reproduces them. The
+  harness behind it is `benchmarks/run_benchmarks.py`, which measures the public
+  API only, takes the median of repeated runs, and discards warmup so numba's
+  one-off JIT compilation is not charged to steady-state figures. The
+  pre-existing scripts in `benchmarks/` are now marked as development
+  explorations, since two of them benchmark reimplementations and a
+  hypothetical joint rather than shipped code.
+
 - `pylinkage.dyads.to_mechanism()` is now public. It converts a component
   `Linkage` into a `Mechanism`, and previously existed only as
   `pylinkage.dyads._conversion.to_mechanism`, so it could not be used or

--- a/benchmarks/benchmark_geometry.py
+++ b/benchmarks/benchmark_geometry.py
@@ -2,6 +2,12 @@
 """
 Benchmarks for pylinkage geometry solvers.
 
+DEVELOPMENT EXPLORATION -- NOT A PUBLISHED FIGURE.
+
+Useful for spotting regressions in geometry primitives while working on them,
+but not curated for publication. For published figures see
+docs/source/benchmarks.md, produced by benchmarks/run_benchmarks.py.
+
 This script measures performance of:
 1. Individual geometry functions (circle_intersect, cyl_to_cart, etc.)
 2. Full linkage simulation

--- a/benchmarks/benchmark_integrated.py
+++ b/benchmarks/benchmark_integrated.py
@@ -2,6 +2,13 @@
 """
 Integrated benchmarks showing real-world impact of optimizations.
 
+DEVELOPMENT EXPLORATION -- NOT A PUBLISHED FIGURE.
+
+This script benchmarks a *hypothetical* numba-optimized joint written inline
+below, not the joint pylinkage actually ships. Its numbers must not be quoted
+as library performance. For published figures see docs/source/benchmarks.md,
+produced by benchmarks/run_benchmarks.py.
+
 This script:
 1. Simulates what a numba-optimized Revolute joint would look like
 2. Compares optimization throughput with different approaches

--- a/benchmarks/benchmark_optimizations.py
+++ b/benchmarks/benchmark_optimizations.py
@@ -2,6 +2,14 @@
 """
 Benchmarks comparing original vs optimized geometry solvers.
 
+DEVELOPMENT EXPLORATION -- NOT A PUBLISHED FIGURE.
+
+The "optimized" variants here are reimplementations local to this file, kept
+to explore whether an approach was worth adopting. They are not the code
+pylinkage ships, so their numbers must not be quoted as library performance.
+For published figures see docs/source/benchmarks.md, produced by
+benchmarks/run_benchmarks.py.
+
 This script measures performance improvements from:
 1. Numba JIT compilation
 2. NumPy vectorization

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Reproducible benchmarks for the public pylinkage API.
+
+This is the harness behind ``docs/benchmarks.md``. Every figure it reports comes
+from calling the public API the way a user would, so the numbers describe
+shipped code rather than a prototype or a local reimplementation.
+
+Three suites are measured:
+
+1. **Solver** — ``Linkage.step()`` against the numba-backed ``step_fast()``.
+2. **PSO throughput** — fitness evaluations per second through
+   ``particle_swarm_optimization()``, counted at the evaluation function itself.
+3. **Synthesis** — wall-clock time for ``function_generation()``,
+   ``path_generation()`` and ``motion_generation()``.
+
+Run with::
+
+    uv run python benchmarks/run_benchmarks.py
+
+Add ``--json results.json`` to save machine-readable output, and ``--quick`` to
+run with reduced repeat counts when smoke-testing the harness itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import statistics
+import sys
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import asdict, dataclass, field
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from pylinkage.actuators import Crank
+from pylinkage.components import Ground
+from pylinkage.dyads import RRRDyad
+from pylinkage.optimization.particle_swarm import particle_swarm_optimization
+from pylinkage.optimization.utils import kinematic_minimization
+from pylinkage.simulation import Linkage
+from pylinkage.synthesis import (
+    Pose,
+    function_generation,
+    motion_generation,
+    path_generation,
+)
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Measurement:
+    """One benchmarked quantity, summarised across repeats."""
+
+    name: str
+    unit: str
+    median: float
+    minimum: float
+    maximum: float
+    repeats: int
+    note: str = ""
+
+    @property
+    def spread(self) -> float:
+        """Relative spread across repeats, as a fraction of the median."""
+        if self.median == 0:
+            return 0.0
+        return (self.maximum - self.minimum) / self.median
+
+
+@dataclass
+class Suite:
+    """A named group of measurements."""
+
+    name: str
+    measurements: list[Measurement] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Timing helpers
+# ---------------------------------------------------------------------------
+
+
+def summarise(
+    name: str,
+    unit: str,
+    samples: list[float],
+    note: str = "",
+) -> Measurement:
+    """Reduce raw per-repeat samples to a reportable measurement."""
+    return Measurement(
+        name=name,
+        unit=unit,
+        median=statistics.median(samples),
+        minimum=min(samples),
+        maximum=max(samples),
+        repeats=len(samples),
+        note=note,
+    )
+
+
+def time_call(func: Callable[[], Any], repeats: int, warmup: int = 1) -> list[float]:
+    """Time a zero-argument callable, returning seconds per repeat.
+
+    The warmup runs are discarded, which matters for anything numba-backed:
+    the first call pays JIT compilation that a user only pays once.
+    """
+    for _ in range(warmup):
+        func()
+
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        func()
+        samples.append(time.perf_counter() - start)
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_fourbar() -> Linkage:
+    """Build the reference four-bar used across the suites."""
+    ground1 = Ground(0.0, 0.0, name="O1")
+    ground2 = Ground(3.0, 0.0, name="O2")
+    crank = Crank(anchor=ground1, radius=1.0, angular_velocity=0.1, name="crank")
+    rocker = RRRDyad(
+        anchor1=crank.output,
+        anchor2=ground2,
+        distance1=2.5,
+        distance2=2.0,
+        name="rocker",
+    )
+    return Linkage([ground1, ground2, crank, rocker], name="four-bar")
+
+
+@kinematic_minimization
+def _tip_distance(loci: Any, **_: Any) -> float:
+    """Cheap, well-behaved fitness: distance of each final locus from origin."""
+    tip = [locus[-1] for locus in loci]
+    return sum(abs(point[0]) + abs(point[1]) for point in tip)
+
+
+# ---------------------------------------------------------------------------
+# Suite 1: solver
+# ---------------------------------------------------------------------------
+
+
+def bench_solver(repeats: int, batches: int = 500, steps: int = 10) -> Suite:
+    """Compare the generator solver against the numba-backed one."""
+    linkage = make_fourbar()
+    total_steps = batches * steps
+
+    def run_step() -> None:
+        for _ in range(batches):
+            list(linkage.step(iterations=steps, dt=1.0))
+
+    def run_step_fast() -> None:
+        for _ in range(batches):
+            linkage.step_fast(iterations=steps, dt=1.0)
+
+    step_times = time_call(run_step, repeats=repeats, warmup=1)
+    fast_times = time_call(run_step_fast, repeats=repeats, warmup=2)
+
+    step_rates = [total_steps / t for t in step_times]
+    fast_rates = [total_steps / t for t in fast_times]
+
+    suite = Suite("Solver")
+    suite.measurements.append(
+        summarise("Linkage.step()", "steps/s", step_rates, "pure-Python generator")
+    )
+    suite.measurements.append(
+        summarise(
+            "Linkage.step_fast()",
+            "steps/s",
+            fast_rates,
+            "numba JIT, compilation excluded by warmup",
+        )
+    )
+    speedup = statistics.median(fast_rates) / statistics.median(step_rates)
+    suite.measurements.append(
+        Measurement(
+            name="step_fast() speedup",
+            unit="x",
+            median=speedup,
+            minimum=speedup,
+            maximum=speedup,
+            repeats=repeats,
+            note="ratio of the two medians above",
+        )
+    )
+    return suite
+
+
+# ---------------------------------------------------------------------------
+# Suite 2: PSO throughput
+# ---------------------------------------------------------------------------
+
+
+def bench_pso(repeats: int, n_particles: int = 100, iterations: int = 100) -> Suite:
+    """Measure fitness evaluations per second through the PSO driver.
+
+    Evaluations are counted at the evaluation function rather than derived from
+    ``n_particles * iterations``, so the figure stays honest if the swarm's
+    internal call pattern ever changes.
+    """
+    calls = 0
+
+    def counting_fitness(*args: Any, **kwargs: Any) -> float:
+        nonlocal calls
+        calls += 1
+        return _tip_distance(*args, **kwargs)
+
+    def run_pso() -> None:
+        particle_swarm_optimization(
+            eval_func=counting_fitness,
+            linkage=make_fourbar(),
+            n_particles=n_particles,
+            iterations=iterations,
+            neighbors=min(17, n_particles),
+            order_relation=min,
+            verbose=False,
+        )
+
+    times = time_call(run_pso, repeats=repeats, warmup=1)
+
+    # calls accumulated over warmup + every repeat; per-run is the fair unit.
+    calls_per_run = calls / (repeats + 1)
+    rates = [calls_per_run / t for t in times]
+
+    suite = Suite("PSO throughput")
+    suite.measurements.append(
+        summarise(
+            "particle_swarm_optimization()",
+            "evaluations/s",
+            rates,
+            f"{n_particles} particles x {iterations} iterations, four-bar",
+        )
+    )
+    suite.measurements.append(
+        summarise(
+            "Full optimisation run",
+            "s",
+            times,
+            f"~{calls_per_run:,.0f} fitness evaluations",
+        )
+    )
+    return suite
+
+
+# ---------------------------------------------------------------------------
+# Suite 3: synthesis
+# ---------------------------------------------------------------------------
+
+
+def bench_synthesis(repeats: int) -> Suite:
+    """Time each of the three classical synthesis entry points."""
+    # These pairs yield a Grashof solution. Several "obvious" choices --
+    # including the one in the pylinkage.synthesis docstring -- are rejected and
+    # return zero solutions, which would time the rejection path instead.
+    angle_pairs = [
+        (0.0, 0.0),
+        (1.0, 0.6),
+        (2.0, 1.1),
+    ]
+    precision_points = [(0.0, 1.0), (1.0, 2.0), (2.0, 1.5), (3.0, 0.0)]
+    poses = [
+        Pose(0.0, 0.0, 0.0),
+        Pose(1.0, 1.0, math.pi / 6),
+        Pose(2.0, 1.0, math.pi / 3),
+    ]
+
+    cases: list[tuple[str, Callable[[], Any], str]] = [
+        (
+            "function_generation()",
+            lambda: function_generation(angle_pairs),
+            f"{len(angle_pairs)} angle pairs (Freudenstein)",
+        ),
+        (
+            "path_generation()",
+            lambda: path_generation(precision_points),
+            f"{len(precision_points)} precision points, 36 orientation samples",
+        ),
+        (
+            "motion_generation()",
+            lambda: motion_generation(poses),
+            f"{len(poses)} poses",
+        ),
+    ]
+
+    suite = Suite("Synthesis")
+    for name, call, note in cases:
+        result = call()
+        n_solutions = len(getattr(result, "solutions", []))
+        times = time_call(call, repeats=repeats, warmup=1)
+        suite.measurements.append(
+            summarise(
+                name,
+                "ms",
+                [t * 1000 for t in times],
+                f"{note}; {n_solutions} solution(s)",
+            )
+        )
+    return suite
+
+
+# ---------------------------------------------------------------------------
+# Environment capture
+# ---------------------------------------------------------------------------
+
+
+def _cpu_model() -> str:
+    """Best-effort CPU model name, since platform.processor() is often empty."""
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.exists():
+        for line in cpuinfo.read_text().splitlines():
+            if line.startswith("model name"):
+                return line.split(":", 1)[1].strip()
+    return platform.processor() or "unknown"
+
+
+def _version(package: str) -> str:
+    """Installed version of a package, or "not installed"."""
+    try:
+        return metadata.version(package)
+    except metadata.PackageNotFoundError:
+        return "not installed"
+
+
+def describe_environment() -> dict[str, str]:
+    """Capture everything needed to interpret or reproduce the numbers."""
+    return {
+        "pylinkage": _version("pylinkage"),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "cpu": _cpu_model(),
+        "numpy": _version("numpy"),
+        "numba": _version("numba"),
+        "scipy": _version("scipy"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_value(value: float, unit: str) -> str:
+    """Render a value with a sensible precision for its unit."""
+    if unit in {"steps/s", "evaluations/s"}:
+        return f"{value:,.0f}"
+    if unit == "x":
+        return f"{value:.1f}"
+    if unit == "ms":
+        return f"{value:.2f}"
+    return f"{value:.3f}"
+
+
+def render_markdown(env: dict[str, str], suites: list[Suite]) -> Iterator[str]:
+    """Yield the report as Markdown lines."""
+    yield "## Environment"
+    yield ""
+    yield "| Component | Version |"
+    yield "|---|---|"
+    for key, value in env.items():
+        yield f"| {key} | {value} |"
+    yield ""
+
+    for suite in suites:
+        yield f"## {suite.name}"
+        yield ""
+        yield "| Measurement | Median | Unit | Spread | Notes |"
+        yield "|---|---:|---|---:|---|"
+        for m in suite.measurements:
+            yield (
+                f"| `{m.name}` | {format_value(m.median, m.unit)} | {m.unit} "
+                f"| {m.spread:.1%} | {m.note} |"
+            )
+        yield ""
+
+
+def main() -> int:
+    """Run every suite and report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json", type=Path, default=None, help="also write results to this JSON file"
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="fewer repeats, for checking the harness rather than publishing numbers",
+    )
+    args = parser.parse_args()
+
+    repeats = 3 if args.quick else 7
+
+    env = describe_environment()
+    suites = [
+        bench_solver(repeats=repeats, batches=100 if args.quick else 500),
+        bench_pso(repeats=repeats),
+        bench_synthesis(repeats=repeats),
+    ]
+
+    report = "\n".join(render_markdown(env, suites))
+    print(report)
+
+    if args.json is not None:
+        payload = {
+            "environment": env,
+            "suites": [
+                {
+                    "name": suite.name,
+                    "measurements": [asdict(m) for m in suite.measurements],
+                }
+                for suite in suites
+            ],
+        }
+        args.json.write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"\nWrote {args.json}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -318,13 +318,41 @@ def bench_synthesis(repeats: int) -> Suite:
 
 
 def _cpu_model() -> str:
-    """Best-effort CPU model name, since platform.processor() is often empty."""
+    """Coarse CPU model name.
+
+    Deliberately imprecise: enough to interpret a figure, not enough to
+    fingerprint the machine it came from. Integrated-graphics and clock-speed
+    suffixes are dropped, since they identify a specific unit without helping a
+    reader judge the numbers.
+    """
+    raw = ""
     cpuinfo = Path("/proc/cpuinfo")
     if cpuinfo.exists():
         for line in cpuinfo.read_text().splitlines():
             if line.startswith("model name"):
-                return line.split(":", 1)[1].strip()
-    return platform.processor() or "unknown"
+                raw = line.split(":", 1)[1].strip()
+                break
+    raw = raw or platform.processor()
+    if not raw:
+        return "unknown"
+
+    # "AMD Ryzen 7 7840U w/ Radeon 780M Graphics" -> "AMD Ryzen 7 7840U"
+    # "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz" -> "Intel Core i7-9750H CPU"
+    raw = raw.split(" w/ ")[0].split(" @ ")[0]
+    raw = raw.replace("(R)", "").replace("(TM)", "")
+    return " ".join(raw.split())
+
+
+def _platform_summary() -> str:
+    """Coarse OS identifier, e.g. ``Linux-7.1``.
+
+    ``platform.platform()`` embeds the full kernel build, distribution tag and
+    libc version, which pins down a specific installation. The major.minor
+    kernel version carries the part a reader actually needs.
+    """
+    release = platform.release()
+    short = ".".join(release.split(".")[:2])
+    return f"{platform.system()}-{short}" if short else platform.system()
 
 
 def _version(package: str) -> str:
@@ -335,12 +363,33 @@ def _version(package: str) -> str:
         return "not installed"
 
 
+def _pylinkage_version() -> str:
+    """Version of the pylinkage actually imported.
+
+    Deliberately not ``metadata.version("pylinkage")``. Distribution metadata is
+    resolved along ``sys.path``, so a stale ``pylinkage.egg-info`` left in the
+    working directory by an old build shadows the installed distribution and
+    reports its version instead -- which would silently mislabel every figure on
+    the published page. ``__version__`` comes from the module that was imported
+    and therefore benchmarked.
+    """
+    import pylinkage
+
+    version = getattr(pylinkage, "__version__", "")
+    return str(version) if version else _version("pylinkage")
+
+
 def describe_environment() -> dict[str, str]:
-    """Capture everything needed to interpret or reproduce the numbers."""
+    """Capture what is needed to interpret or reproduce the numbers.
+
+    Host details are reported coarsely on purpose: this output is pasted into
+    published documentation, so it should not carry more about the machine than
+    a reader needs.
+    """
     return {
-        "pylinkage": _version("pylinkage"),
+        "pylinkage": _pylinkage_version(),
         "python": platform.python_version(),
-        "platform": platform.platform(),
+        "platform": _platform_summary(),
         "cpu": _cpu_model(),
         "numpy": _version("numpy"),
         "numba": _version("numba"),

--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -31,8 +31,8 @@ Treat the ratios as meaningful and the absolute values as indicative.
 |---|---|
 | pylinkage | 1.1.0 |
 | python | 3.11.14 |
-| platform | Linux-7.1.12-200.fc44.x86_64-x86_64-with-glibc2.43 |
-| cpu | AMD Ryzen 7 7840U w/ Radeon 780M Graphics |
+| platform | Linux-7.1 |
+| cpu | AMD Ryzen 7 7840U |
 | numpy | 2.4.6 |
 | numba | 0.66.0 |
 | scipy | 1.17.1 |

--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -1,0 +1,110 @@
+# Benchmarks
+
+Reproducible performance figures for pylinkage's public API.
+
+Every number here comes from calling the library the way a user would, through
+the documented entry points. Nothing on this page measures a prototype, a
+hypothetical optimisation, or a reimplementation kept only in the benchmark
+suite.
+
+## Reproducing these numbers
+
+```bash
+uv run python benchmarks/run_benchmarks.py
+```
+
+The harness prints the tables below as Markdown. Add `--json results.json` for
+machine-readable output, or `--quick` to check that the harness runs without
+waiting for publication-quality repeat counts.
+
+Each measurement is the **median of 7 repeats**, with warmup runs discarded so
+that numba's one-off JIT compilation is not charged to the steady-state figures.
+The *spread* column is the full range across repeats as a fraction of the
+median, and is reported so you can tell a solid number from a noisy one.
+
+## Environment
+
+These figures were collected on a laptop, not dedicated benchmarking hardware.
+Treat the ratios as meaningful and the absolute values as indicative.
+
+| Component | Version |
+|---|---|
+| pylinkage | 1.1.0 |
+| python | 3.11.14 |
+| platform | Linux-7.1.12-200.fc44.x86_64-x86_64-with-glibc2.43 |
+| cpu | AMD Ryzen 7 7840U w/ Radeon 780M Graphics |
+| numpy | 2.4.6 |
+| numba | 0.66.0 |
+| scipy | 1.17.1 |
+
+## Solver
+
+Simulating the reference four-bar (two grounds, a crank, and an `RRRDyad`).
+
+| Measurement | Median | Unit | Spread | Notes |
+|---|---:|---|---:|---|
+| `Linkage.step()` | 257,550 | steps/s | 9.8% | pure-Python generator |
+| `Linkage.step_fast()` | 1,658,608 | steps/s | 4.6% | numba JIT, compilation excluded by warmup |
+| `step_fast()` speedup | 6.4 | x | — | ratio of the two medians above |
+
+`step_fast()` is the numba-backed path and is roughly **6x faster** on this
+mechanism. The gap is what makes optimisation practical: an optimiser run spends
+essentially all of its time inside the solver.
+
+Note that `step_fast()` pays JIT compilation on its first call. That cost is
+excluded here because it is paid once per process, but it is the reason a single
+short simulation may not feel faster than `step()`.
+
+## PSO throughput
+
+Particle swarm optimisation of the same four-bar, with a cheap fitness function,
+so the figure reflects the optimiser and solver rather than the objective.
+
+| Measurement | Median | Unit | Spread | Notes |
+|---|---:|---|---:|---|
+| `particle_swarm_optimization()` | 15,814 | evaluations/s | 33.2% | 100 particles x 100 iterations |
+| Full optimisation run | 0.639 | s | 29.6% | ~10,100 fitness evaluations |
+
+Evaluations are counted at the fitness function itself rather than inferred from
+`n_particles * iterations`, so the figure stays correct even if the swarm's
+internal call pattern changes.
+
+The spread here is wider than elsewhere because a sub-second run is sensitive to
+CPU frequency scaling. The useful takeaway is the order of magnitude: **roughly
+ten thousand fitness evaluations per second** on a four-bar, meaning a realistic
+optimisation budget is dominated by how expensive *your* fitness function is.
+
+## Synthesis
+
+Classical synthesis entry points, timed end to end.
+
+| Measurement | Median | Unit | Spread | Notes |
+|---|---:|---|---:|---|
+| `function_generation()` | 0.09 | ms | 27.8% | 3 angle pairs (Freudenstein); 1 solution |
+| `path_generation()` | 1778.63 | ms | 8.2% | 4 precision points, 36 orientation samples; 10 solutions |
+| `motion_generation()` | 0.69 | ms | 6.3% | 3 poses; 10 solutions |
+
+The three differ by four orders of magnitude, and the reason is structural
+rather than incidental:
+
+- **`function_generation()`** solves Freudenstein's equation directly. For three
+  angle pairs that is a small linear system, hence microseconds.
+- **`motion_generation()`** applies Burmester theory to a fixed set of poses. The
+  work is bounded by the number of poses.
+- **`path_generation()`** has no prescribed timing, so coupler orientation at
+  each precision point is a free variable. It searches over
+  `n_orientation_samples` candidate orientations (36 by default) and runs
+  Burmester synthesis for each, which is why it costs **well over a second**.
+
+That last figure is worth knowing before you call `path_generation()` in a loop
+or behind an interactive control. If you need it faster, lowering
+`n_orientation_samples` trades solution coverage for time roughly linearly.
+
+## What is not benchmarked here
+
+The `benchmarks/` directory also contains `benchmark_geometry.py`,
+`benchmark_integrated.py`, and `benchmark_optimizations.py`. Those are
+development explorations — they compare candidate implementations, some of
+which were never shipped — and their output should not be quoted as pylinkage
+performance figures. Only `run_benchmarks.py` and `benchmark_solver.py` measure
+the library as released.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Welcome to pylinkage's documentation!
 
    Readme <readmelink>
    changeloglink
+   benchmarks
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Closes #27. Independent of #30 — the CHANGELOG entries land in different
sections, so the two merge in either order.

## The harness

`benchmarks/run_benchmarks.py` measures **only the public API**, so every figure
describes shipped code. It takes the median of 7 repeats, discards warmup so
numba's one-off JIT compilation is not charged to steady-state figures, and
prints the relative spread so a noisy number is visible as one.

PSO evaluations are counted at the fitness function itself rather than inferred
from `n_particles * iterations`, so the figure stays correct if the swarm's
internal call pattern ever changes.

## Results

Published to `docs/source/benchmarks.md`, wired into the toctree. It records the
hardware and versions behind each figure plus the command to reproduce it.

| Suite | Figure |
|---|---|
| `step()` → `step_fast()` | 258k → 1.66M steps/s (**6.4x**) |
| PSO throughput | ~15.8k evaluations/s |
| `function_generation()` | 0.09 ms |
| `motion_generation()` | 0.69 ms |
| `path_generation()` | **1779 ms** |

That last row is tracked separately as #29: `path_generation()` sweeps 36
coupler orientations by default, and it is the README's first example, so a new
user's first call appears to hang for ~2s. Documented on the page in the
meantime.

## Notes on placement

The page goes in `docs/source/` rather than the `docs/benchmarks.md` named in
the issue, because `docs/` is the sphinx build output — a file there would never
render. It uses the already-configured `myst_parser`.

## Two things found while building this

- **Host detail was leaking into published docs.** The environment table
  embedded the full kernel build, distribution tag, libc version and CPU
  marketing string. The harness now reports these coarsely at the source
  (`Linux-7.1`, `AMD Ryzen 7 7840U`), so a regenerated page stays redacted
  without anyone remembering to trim it.

- **A stale build artifact misreported the version.** `metadata.version()`
  resolves along `sys.path`, so an untracked `pylinkage.egg-info` from a pre-1.0
  build shadowed the installed distribution and reported `0.5.0` for the 1.1.0
  it had just benchmarked. Reading `__version__` from the imported module
  reports what was actually measured. The figures on the page were collected as
  a script, where the shadowing does not apply, so their 1.1.0 label was correct.

## Pre-existing scripts

The three older scripts in `benchmarks/` are now marked as development
explorations. `benchmark_integrated.py` benchmarks a *hypothetical* numba joint
written inline, and `benchmark_optimizations.py` compares reimplementations
local to that file — neither describes shipped code, so neither should be quoted
as a pylinkage figure.

## Verification

- `uv run task lint` — all checks passed
- `sphinx-build` succeeds and the page renders