### PR TITLE
docs: parse Google-style docstrings, and fix the malformed ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Docstrings rendered wrongly in the API reference.** The codebase writes
+  Google-style docstrings (`Args:`, `Returns:`, `Raises:`), but the docs never
+  enabled `sphinx.ext.napoleon`, so every one of them was parsed as a
+  definition list: parameter descriptions were swallowed as stray indentation,
+  and `*args` / `**kwargs` were read as emphasis markup. Enabling napoleon
+  renders them as proper parameter tables. `napoleon_use_ivar` is set alongside
+  it so a documented attribute does not collide with the entry autodoc already
+  generates for the same dataclass field, and package-level `automodule`
+  directives are marked `:no-index:` so each object is indexed once rather than
+  once per re-export. Nine genuinely malformed docstrings were fixed by hand:
+  bullet lists and formula blocks missing their preceding blank line, isomer
+  signatures such as `RRT_` that RST read as link targets, and an empty
+  `Conversion:` section in `pylinkage.mechanism` left behind when the
+  mechanism/linkage conversion helpers were removed. Docs build warnings drop
+  from 496 to 76, with none remaining from docstrings.
+
 - **Stale API reference.** `docs/source/api/` was checked-in `sphinx-apidoc`
   output that had not been regenerated since before 1.0. It documented three
   modules that no longer exist — the legacy `pylinkage.joints` package removed

--- a/docs/source/api/pylinkage.actuators.rst
+++ b/docs/source/api/pylinkage.actuators.rst
@@ -35,3 +35,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.assur.rst
+++ b/docs/source/api/pylinkage.assur.rst
@@ -83,3 +83,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.bridge.rst
+++ b/docs/source/api/pylinkage.bridge.rst
@@ -19,3 +19,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.cam.rst
+++ b/docs/source/api/pylinkage.cam.rst
@@ -27,3 +27,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.components.rst
+++ b/docs/source/api/pylinkage.components.rst
@@ -27,3 +27,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.dyads.rst
+++ b/docs/source/api/pylinkage.dyads.rst
@@ -67,3 +67,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.geometry.rst
+++ b/docs/source/api/pylinkage.geometry.rst
@@ -27,3 +27,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.hypergraph.rst
+++ b/docs/source/api/pylinkage.hypergraph.rst
@@ -59,3 +59,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.linkage.rst
+++ b/docs/source/api/pylinkage.linkage.rst
@@ -35,3 +35,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.mechanism.rst
+++ b/docs/source/api/pylinkage.mechanism.rst
@@ -59,3 +59,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.optimization.collections.rst
+++ b/docs/source/api/pylinkage.optimization.collections.rst
@@ -35,3 +35,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.optimization.rst
+++ b/docs/source/api/pylinkage.optimization.rst
@@ -107,3 +107,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.population.rst
+++ b/docs/source/api/pylinkage.population.rst
@@ -8,3 +8,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.rst
+++ b/docs/source/api/pylinkage.rst
@@ -52,3 +52,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.simulation.rst
+++ b/docs/source/api/pylinkage.simulation.rst
@@ -19,3 +19,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.solver.rst
+++ b/docs/source/api/pylinkage.solver.rst
@@ -67,3 +67,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.symbolic.rst
+++ b/docs/source/api/pylinkage.symbolic.rst
@@ -59,3 +59,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.synthesis.rst
+++ b/docs/source/api/pylinkage.synthesis.rst
@@ -107,3 +107,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.topology.data.rst
+++ b/docs/source/api/pylinkage.topology.data.rst
@@ -8,3 +8,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.topology.rst
+++ b/docs/source/api/pylinkage.topology.rst
@@ -51,3 +51,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/api/pylinkage.visualizer.rst
+++ b/docs/source/api/pylinkage.visualizer.rst
@@ -91,3 +91,4 @@ Module contents
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,10 +36,19 @@ extensions = [
     # Use docstrings
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    # Parse Google-style docstrings ("Args:", "Returns:", "Raises:").
+    # Without this they are read as definition lists, and "*args"/"**kwargs"
+    # are read as emphasis markup.
+    "sphinx.ext.napoleon",
     # Useful for markdown integration
     "myst_parser",
     "sphinx.ext.githubpages",
 ]
+
+# Render "Attributes:" as :ivar: fields rather than standalone .. attribute::
+# directives. Without this, a documented attribute collides with the entry
+# autodoc already generates for the same dataclass field.
+napoleon_use_ivar = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/src/pylinkage/assur/groups.py
+++ b/src/pylinkage/assur/groups.py
@@ -136,6 +136,7 @@ class Dyad(AssurGroup):
         (joint_0)               (joint_1)                 (joint_2)
 
     For prismatic variants, additional line-defining nodes are stored:
+
     - RRP/RPR/PRR: one line defined by (line_node1, line_node2)
     - PP: two lines defined by (line_node1, line_node2) and
       (line2_node1, line2_node2)

--- a/src/pylinkage/dyads/factory.py
+++ b/src/pylinkage/dyads/factory.py
@@ -9,9 +9,11 @@ Notation:
     _ = Guide (rail/slot that slider moves along)
 
 The 12 isomers map to 3 geometry types:
-    - RRR: circle-circle intersection
-    - Circle-line isomers (RR_T, RRT_, RT_R, R_T_T, RT_T_, R_TT_, RT__T): RRPDyad
-    - Line-line isomers (T_R_T, T_RT_, _TRT_): PPDyad
+
+- ``RRR``: circle-circle intersection
+- Circle-line isomers (``RR_T``, ``RRT_``, ``RT_R``, ``R_T_T``, ``RT_T_``,
+  ``R_TT_``, ``RT__T``): RRPDyad
+- Line-line isomers (``T_R_T``, ``T_RT_``, ``_TRT_``): PPDyad
 """
 
 from __future__ import annotations

--- a/src/pylinkage/dyads/pp.py
+++ b/src/pylinkage/dyads/pp.py
@@ -1,7 +1,8 @@
 """PPDyad - line-line intersection.
 
 A PP dyad consists of two prismatic constraints, positioning a joint
-at the intersection of two lines. This covers isomers like T_R_T, T_RT_, _TRT_.
+at the intersection of two lines. This covers isomers like ``T_R_T``,
+``T_RT_`` and ``_TRT_``.
 """
 
 from __future__ import annotations

--- a/src/pylinkage/mechanism/__init__.py
+++ b/src/pylinkage/mechanism/__init__.py
@@ -33,7 +33,6 @@ Classes:
     Mechanism: The main orchestrator class
     MechanismBuilder: Links-first builder for creating mechanisms
 
-Conversion:
 Serialization:
     mechanism_to_dict: Serialize to dictionary
     mechanism_from_dict: Deserialize from dictionary

--- a/src/pylinkage/solver/groups.py
+++ b/src/pylinkage/solver/groups.py
@@ -153,7 +153,7 @@ def solve_pp_dyad(
     A PP dyad consists of one internal node constrained to lie at the
     intersection of two lines. Each line is defined by two points.
 
-    This is used for isomers like T_R_T, T_RT_, _TRT_.
+    This is used for isomers like ``T_R_T``, ``T_RT_`` and ``_TRT_``.
 
     Args:
         line1_pos1: Position (x, y) of the first point on line 1.

--- a/src/pylinkage/symbolic/geometry.py
+++ b/src/pylinkage/symbolic/geometry.py
@@ -87,6 +87,7 @@ def symbolic_circle_intersect(
     which intersection point to return.
 
     Algorithm (Paul Bourke, 1997):
+
     - d = distance between centers
     - a = (r1^2 - r2^2 + d^2) / (2*d) : distance from center1 to radical line
     - h = sqrt(r1^2 - a^2) : half-chord length

--- a/src/pylinkage/synthesis/burmester.py
+++ b/src/pylinkage/synthesis/burmester.py
@@ -10,6 +10,7 @@ linkages that pass through a set of precision positions. The key concepts:
   fixed pivots (ground joints) of the linkage.
 
 For exact synthesis:
+
 - 3 positions: Every body-frame point is a valid circle point (∞ solutions)
 - 4 positions: Circle points form a curve (circular cubic); we find points
   where all 4 world positions are concyclic

--- a/src/pylinkage/synthesis/conversion.py
+++ b/src/pylinkage/synthesis/conversion.py
@@ -122,6 +122,7 @@ def solution_to_linkage(
     """Convert a single FourBarSolution to a Linkage object.
 
     Creates a four-bar linkage with:
+
     - Two Ground components as ground pivots
     - One Crank as motor input
     - One RRRDyad connecting crank to rocker

--- a/src/pylinkage/synthesis/function_generation.py
+++ b/src/pylinkage/synthesis/function_generation.py
@@ -167,7 +167,8 @@ def coefficients_to_link_lengths(
     Given R1, R2, R3 and choosing ground length d, solve for the
     link lengths a (crank), b (coupler), c (rocker).
 
-    The relationships are:
+    The relationships are::
+
         R1 = d/a  =>  a = d/R1
         R2 = d/c  =>  c = d/R2
         R3 = (a^2 - b^2 + c^2 + d^2) / (2*a*c)


### PR DESCRIPTION
Follow-up to #30, which surfaced these once the previously-undocumented
subpackages started rendering.

## Root cause

The codebase writes **Google-style docstrings** (`Args:`, `Returns:`, `Raises:`),
but `conf.py` never enabled `sphinx.ext.napoleon`.

Without it, every `Args:` block was parsed as a definition list. Parameter
descriptions became stray indentation, and `*args` / `**kwargs` were read as
emphasis markup — which is why the warnings clustered on
`set_constraints` across a dozen classes. Beyond the noise, **parameter
documentation was not rendering as parameters at all.**

## Changes

| Change | Why |
|---|---|
| Enable `sphinx.ext.napoleon` | Parse the docstring style the codebase actually uses |
| `napoleon_use_ivar = True` | Stops a documented attribute colliding with the entry autodoc already emits for the same dataclass field |
| `:no-index:` on package-level `automodule` | Index each object once, not once per re-export |

The second and third are not incidental: enabling napoleon alone multiplied
duplicate object descriptions to 630, because its attribute entries collided
with autodoc's on pages that already documented everything twice.

### Nine genuinely malformed docstrings

- Bullet lists and one formula block missing the blank line that separates them
  from the paragraph above (`assur/groups.py`, `symbolic/geometry.py`,
  `synthesis/burmester.py`, `synthesis/conversion.py`,
  `synthesis/function_generation.py`)
- Isomer signatures such as `RRT_`, `T_RT_`, `_TRT_` whose trailing underscore
  RST reads as a link target, producing `Unknown target name` errors — now
  inline literals (`dyads/factory.py`, `dyads/pp.py`, `solver/groups.py`)
- An empty `Conversion:` section header in `pylinkage.mechanism`, left behind
  when the mechanism/linkage conversion helpers were deleted

## Result

| | Before | After |
|---|---:|---:|
| Docstring (docutils) | 174 | **0** |
| Duplicate object descriptions | 2 | **0** |
| Ambiguous cross-references | 272 | 38 |
| Total build warnings | 496 | **76** |

What remains is 38 ambiguous cross-references from re-exports and 38 README
links pointing outside the docs tree. Neither is a docstring problem and neither
is touched here.

## Verification

- `sphinx-build` succeeds; `Args:` now renders as Parameters tables (53 on the dyads page alone), with no raw `Args:` text left unparsed
- `uv run task lint` — all checks passed
- `uv run task typecheck` — no issues in 133 source files
- `uv run pytest` — 2448 passed, 5 skipped