### PR TITLE
refactor(docs): unify docstrings on Google style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One docstring style across the codebase.** Docstrings were split between
+  two conventions: 85 files used Google style (`Args:`) while 16 used reST
+  field lists (`:param:`), and `linkage/transmission.py` used both at once. The
+  16 reST files — concentrated in `symbolic/`, `optimization/` and `geometry/`,
+  the oldest code in the package — are converted to Google style, so all 100
+  documented modules now read the same way. This is presentation only: 393
+  fields were rewritten with no change to wording, and the sole vocabulary
+  removed across all 16 files is the `param`/`returns`/`raises` markers
+  themselves. Sphinx cross-reference roles such as ``:func:`max` `` are
+  untouched, being valid in Google-style docstrings.
+
 - The `full` extra now includes `pymoo`, so `pip install pylinkage[full]`
   covers multi-objective optimization as the README's "all optional backends"
   description promises. `moo` remains available on its own, and is now listed

--- a/src/pylinkage/geometry/core.py
+++ b/src/pylinkage/geometry/core.py
@@ -16,11 +16,14 @@ def dist(x1: float, y1: float, x2: float, y2: float) -> float:
     """
     Distance between two points.
 
-    :param x1: X coordinate of first point.
-    :param y1: Y coordinate of first point.
-    :param x2: X coordinate of second point.
-    :param y2: Y coordinate of second point.
-    :return: Euclidean distance.
+    Args:
+        x1: X coordinate of first point.
+        y1: Y coordinate of first point.
+        x2: X coordinate of second point.
+        y2: Y coordinate of second point.
+
+    Returns:
+        Euclidean distance.
     """
     dx = x1 - x2
     dy = y1 - y2
@@ -34,11 +37,14 @@ def sqr_dist(x1: float, y1: float, x2: float, y2: float) -> float:
 
     Faster than dist when only comparing distances.
 
-    :param x1: X coordinate of first point.
-    :param y1: Y coordinate of first point.
-    :param x2: X coordinate of second point.
-    :param y2: Y coordinate of second point.
-    :return: Squared distance.
+    Args:
+        x1: X coordinate of first point.
+        y1: Y coordinate of first point.
+        x2: X coordinate of second point.
+        y2: Y coordinate of second point.
+
+    Returns:
+        Squared distance.
     """
     dx = x1 - x2
     dy = y1 - y2
@@ -57,13 +63,16 @@ def get_nearest_point(
     """
     Return the point closer to the reference.
 
-    :param ref_x: X coordinate of reference point.
-    :param ref_y: Y coordinate of reference point.
-    :param p1_x: X coordinate of first candidate.
-    :param p1_y: Y coordinate of first candidate.
-    :param p2_x: X coordinate of second candidate.
-    :param p2_y: Y coordinate of second candidate.
-    :return: Coordinates of the nearest point.
+    Args:
+        ref_x: X coordinate of reference point.
+        ref_y: Y coordinate of reference point.
+        p1_x: X coordinate of first candidate.
+        p1_y: Y coordinate of first candidate.
+        p2_x: X coordinate of second candidate.
+        p2_y: Y coordinate of second candidate.
+
+    Returns:
+        Coordinates of the nearest point.
     """
     d1 = sqr_dist(ref_x, ref_y, p1_x, p1_y)
     d2 = sqr_dist(ref_x, ref_y, p2_x, p2_y)
@@ -77,9 +86,12 @@ def norm(x: float, y: float) -> float:
     """
     Return the norm of a 2-dimensional vector.
 
-    :param x: X component.
-    :param y: Y component.
-    :return: Vector magnitude.
+    Args:
+        x: X component.
+        y: Y component.
+
+    Returns:
+        Vector magnitude.
     """
     return math.sqrt(x * x + y * y)
 
@@ -93,11 +105,14 @@ def cyl_to_cart(
 ) -> tuple[float, float]:
     """Convert polar coordinates into cartesian.
 
-    :param radius: Distance from origin.
-    :param theta: Angle starting from abscissa axis.
-    :param ori_x: Origin X coordinate (Default value = 0.0).
-    :param ori_y: Origin Y coordinate (Default value = 0.0).
-    :return: Cartesian coordinates (x, y).
+    Args:
+        radius: Distance from origin.
+        theta: Angle starting from abscissa axis.
+        ori_x: Origin X coordinate (Default value = 0.0).
+        ori_y: Origin Y coordinate (Default value = 0.0).
+
+    Returns:
+        Cartesian coordinates (x, y).
     """
     return (radius * math.cos(theta) + ori_x, radius * math.sin(theta) + ori_y)
 
@@ -111,11 +126,14 @@ def line_from_points(
     """
     A cartesian equation of the line joining two points.
 
-    :param first_x: X coordinate of first point.
-    :param first_y: Y coordinate of first point.
-    :param second_x: X coordinate of second point.
-    :param second_y: Y coordinate of second point.
-    :return: A cartesian equation of this line (a, b, c) where ax + by + c = 0.
+    Args:
+        first_x: X coordinate of first point.
+        first_y: Y coordinate of first point.
+        second_x: X coordinate of second point.
+        second_y: Y coordinate of second point.
+
+    Returns:
+        A cartesian equation of this line (a, b, c) where ax + by + c = 0.
     """
     if first_x == second_x and first_y == second_y:
         return (0.0, 0.0, 0.0)

--- a/src/pylinkage/geometry/secants.py
+++ b/src/pylinkage/geometry/secants.py
@@ -34,15 +34,17 @@ def circle_intersect(
     Transcription of a Matt Woodhead program, method provided by Paul Bourke,
     1997. http://paulbourke.net/geometry/circlesphere/.
 
-    :param x1: X coordinate of first circle center.
-    :param y1: Y coordinate of first circle center.
-    :param r1: Radius of first circle.
-    :param x2: X coordinate of second circle center.
-    :param y2: Y coordinate of second circle center.
-    :param r2: Radius of second circle.
-    :param tol: Distance under which two points are considered equal.
+    Args:
+        x1: X coordinate of first circle center.
+        y1: Y coordinate of first circle center.
+        r1: Radius of first circle.
+        x2: X coordinate of second circle center.
+        y2: Y coordinate of second circle center.
+        r2: Radius of second circle.
+        tol: Distance under which two points are considered equal.
 
-    :returns: Tuple of (n_intersections, x1, y1, x2, y2) where:
+    Returns:
+        Tuple of (n_intersections, x1, y1, x2, y2) where:
         - n=0: No intersection (other values undefined)
         - n=1: One intersection at (x1, y1)
         - n=2: Two intersections at (x1, y1) and (x2, y2)
@@ -109,15 +111,17 @@ def circle_line_from_points_intersection(
     """
     Intersection(s) of a circle and a line defined by two points.
 
-    :param cx: X coordinate of circle center.
-    :param cy: Y coordinate of circle center.
-    :param r: Circle radius.
-    :param p1_x: X coordinate of first point on line.
-    :param p1_y: Y coordinate of first point on line.
-    :param p2_x: X coordinate of second point on line.
-    :param p2_y: Y coordinate of second point on line.
+    Args:
+        cx: X coordinate of circle center.
+        cy: Y coordinate of circle center.
+        r: Circle radius.
+        p1_x: X coordinate of first point on line.
+        p1_y: Y coordinate of first point on line.
+        p2_x: X coordinate of second point on line.
+        p2_y: Y coordinate of second point on line.
 
-    :returns: Tuple of (n_intersections, x1, y1, x2, y2) where:
+    Returns:
+        Tuple of (n_intersections, x1, y1, x2, y2) where:
         - n=0: No intersection
         - n=1: One intersection (tangent) at (x1, y1)
         - n=2: Two intersections at (x1, y1) and (x2, y2)
@@ -170,14 +174,16 @@ def circle_line_intersection(
 
     From https://mathworld.wolfram.com/Circle-LineIntersection.html
 
-    :param cx: X coordinate of circle center.
-    :param cy: Y coordinate of circle center.
-    :param r: Circle radius.
-    :param a: Line equation coefficient a (ax + by + c = 0).
-    :param b: Line equation coefficient b.
-    :param c: Line equation coefficient c.
+    Args:
+        cx: X coordinate of circle center.
+        cy: Y coordinate of circle center.
+        r: Circle radius.
+        a: Line equation coefficient a (ax + by + c = 0).
+        b: Line equation coefficient b.
+        c: Line equation coefficient c.
 
-    :returns: Tuple of (n_intersections, x1, y1, x2, y2).
+    Returns:
+        Tuple of (n_intersections, x1, y1, x2, y2).
     """
     # Find two points on the line
     if b != 0:
@@ -199,11 +205,13 @@ def intersection(
 
     The input objects should be points or circles.
 
-    :param obj_1: First point or circle (as tuple).
-    :param obj_2: Second point or circle (as tuple).
-    :param tol: Absolute tolerance to use if provided.
+    Args:
+        obj_1: First point or circle (as tuple).
+        obj_2: Second point or circle (as tuple).
+        tol: Absolute tolerance to use if provided.
 
-    :returns: The intersection found, if any.
+    Returns:
+        The intersection found, if any.
     """
     # Two points
     if len(obj_1) == 2 and len(obj_2) == 2:
@@ -257,16 +265,18 @@ def line_line_intersection(
 
     Uses the parametric line intersection formula.
 
-    :param p1_x: X coordinate of first point on line 1.
-    :param p1_y: Y coordinate of first point on line 1.
-    :param p2_x: X coordinate of second point on line 1.
-    :param p2_y: Y coordinate of second point on line 1.
-    :param p3_x: X coordinate of first point on line 2.
-    :param p3_y: Y coordinate of first point on line 2.
-    :param p4_x: X coordinate of second point on line 2.
-    :param p4_y: Y coordinate of second point on line 2.
+    Args:
+        p1_x: X coordinate of first point on line 1.
+        p1_y: Y coordinate of first point on line 1.
+        p2_x: X coordinate of second point on line 1.
+        p2_y: Y coordinate of second point on line 1.
+        p3_x: X coordinate of first point on line 2.
+        p3_y: Y coordinate of first point on line 2.
+        p4_x: X coordinate of second point on line 2.
+        p4_y: Y coordinate of second point on line 2.
 
-    :returns: Tuple of (n_intersections, x, y) where:
+    Returns:
+        Tuple of (n_intersections, x, y) where:
         - n=0: No intersection (parallel lines)
         - n=1: One intersection at (x, y)
         - n=3: Coincident lines (same line)
@@ -311,9 +321,11 @@ def bounding_box(locus: list[Coord]) -> tuple[float, float, float, float]:
     """
     Compute the bounding box of a locus.
 
-    :param locus: A list of points or any iterable with the same structure.
+    Args:
+        locus: A list of points or any iterable with the same structure.
 
-    :returns: Bounding box as (y_min, x_max, y_max, x_min).
+    Returns:
+        Bounding box as (y_min, x_max, y_max, x_min).
     """
     y_min = float("inf")
     x_min = float("inf")

--- a/src/pylinkage/linkage/analysis.py
+++ b/src/pylinkage/linkage/analysis.py
@@ -23,8 +23,9 @@ def kinematic_default_test(
     This decorator makes a kinematic simulation, before passing the loci to the
     decorated function.
 
-    :param func: Fitness function to be decorated.
-    :param error_penalty: Penalty value for unbuildable linkage. Common values include
+    Args:
+        func: Fitness function to be decorated.
+        error_penalty: Penalty value for unbuildable linkage. Common values include
             float('inf') and 0.
     """
 
@@ -35,12 +36,14 @@ def kinematic_default_test(
     ) -> float:
         """Decorated function.
 
-        :param linkage: The linkage to optimize.
-        :param params: Geometric constraints to pass to linkage.set_constraints.
-        :param init_pos: List of initial positions for the joints. If None it will be
-            redefined at each successful iteration. (Default value = None).
+        Args:
+            linkage: The linkage to optimize.
+            params: Geometric constraints to pass to linkage.set_constraints.
+            init_pos: List of initial positions for the joints. If None it will be
+                redefined at each successful iteration. (Default value = None).
 
-        :return: Fitness score.
+        Returns:
+            Fitness score.
         """
         if init_pos is not None:
             linkage.set_coords(init_pos)
@@ -74,19 +77,22 @@ def extract_trajectory(
     Frames where the joint position is ``None`` (unbuildable configuration) are
     silently skipped.
 
-    :param loci: Sequence of frames as produced by ``Linkage.step()`` or
-        ``Mechanism.step()``. Each frame is a sequence of ``(x, y)`` tuples,
-        one per joint/component in the linkage's iteration order.
-    :param joint: Which joint's trajectory to extract. Can be:
+    Args:
+        loci: Sequence of frames as produced by ``Linkage.step()`` or
+            ``Mechanism.step()``. Each frame is a sequence of ``(x, y)`` tuples,
+            one per joint/component in the linkage's iteration order.
+        joint: Which joint's trajectory to extract. Can be:
 
         - an integer index into each frame (default ``-1`` = last joint),
         - a joint/component name (requires ``linkage``),
         - a joint/component instance (requires ``linkage``).
 
-    :param linkage: The ``Linkage`` or ``Mechanism`` the loci come from.
-        Required when ``joint`` is a name or instance.
+    Args:
+        linkage: The ``Linkage`` or ``Mechanism`` the loci come from.
+            Required when ``joint`` is a name or instance.
 
-    :returns: Pair ``(xs, ys)`` of ``numpy.ndarray`` with the same length.
+    Returns:
+        Pair ``(xs, ys)`` of ``numpy.ndarray`` with the same length.
         Empty arrays if every frame is unbuildable.
     """
     if isinstance(joint, int):
@@ -118,14 +124,16 @@ def extract_trajectories(
     configuration) are skipped *per joint* — each joint's arrays only
     contain frames where that joint was successfully solved.
 
-    :param loci: Sequence of frames as produced by ``Linkage.step()`` or
-        ``Mechanism.step()``. Each frame is a sequence of ``(x, y)``
-        tuples, one per joint/component in the linkage's iteration order.
-    :param linkage: Optional ``Linkage`` or ``Mechanism``. If provided,
-        the returned dict is keyed by joint name; otherwise it is keyed
-        by integer index.
+    Args:
+        loci: Sequence of frames as produced by ``Linkage.step()`` or
+            ``Mechanism.step()``. Each frame is a sequence of ``(x, y)``
+            tuples, one per joint/component in the linkage's iteration order.
+        linkage: Optional ``Linkage`` or ``Mechanism``. If provided,
+            the returned dict is keyed by joint name; otherwise it is keyed
+            by integer index.
 
-    :returns: Mapping ``{joint_name_or_index: (xs, ys)}``. Each ``(xs,
+    Returns:
+        Mapping ``{joint_name_or_index: (xs, ys)}``. Each ``(xs,
         ys)`` pair is a tuple of ``numpy.ndarray`` with matching length.
         Empty arrays indicate a joint was never buildable.
     """
@@ -171,9 +179,11 @@ def _resolve_joint_index(linkage: "Any", joint: "Any") -> int:
 def bounding_box(locus: Iterable[Coord]) -> BoundingBox:
     """Compute the bounding box of a locus.
 
-    :param locus: A list of points or any iterable with the same structure.
+    Args:
+        locus: A list of points or any iterable with the same structure.
 
-    :returns: Bounding box as (y_min, x_max, y_max, x_min).
+    Returns:
+        Bounding box as (y_min, x_max, y_max, x_min).
     """
     y_min = float("inf")
     x_min = float("inf")
@@ -191,9 +201,11 @@ def movement_bounding_box(loci: Iterable[Iterable[Coord]]) -> BoundingBox:
     """
     Bounding box for a group of loci.
 
-    :param loci: Iterable of loci (sequences of coordinates).
+    Args:
+        loci: Iterable of loci (sequences of coordinates).
 
-    :returns: Bounding box as (y_min, x_max, y_max, x_min).
+    Returns:
+        Bounding box as (y_min, x_max, y_max, x_min).
     """
     bb: BoundingBox = (float("inf"), -float("inf"), -float("inf"), float("inf"))
     for locus in loci:

--- a/src/pylinkage/linkage/transmission.py
+++ b/src/pylinkage/linkage/transmission.py
@@ -80,14 +80,16 @@ class TransmissionAngleAnalysis:
         marked with horizontal reference lines, and the y-axis is fixed
         to ``[0, 180]`` so plots are comparable across mechanisms.
 
-        :param ax: Axes to draw on. A new figure is created if ``None``.
-        :param show_limits: Draw red dashed lines at the acceptable-range
-            bounds (default ``[40°, 140°]``).
-        :param show_optimum: Draw a green dotted line at 90° (the
-            transmission-angle optimum).
-        :param title: Plot title. Pass ``None`` to omit.
+        Args:
+            ax: Axes to draw on. A new figure is created if ``None``.
+            show_limits: Draw red dashed lines at the acceptable-range
+                bounds (default ``[40°, 140°]``).
+            show_optimum: Draw a green dotted line at 90° (the
+                transmission-angle optimum).
+            title: Plot title. Pass ``None`` to omit.
 
-        :returns: The Matplotlib axes the plot was drawn on.
+        Returns:
+            The Matplotlib axes the plot was drawn on.
         """
         import matplotlib.pyplot as plt
 

--- a/src/pylinkage/mechanism/factories.py
+++ b/src/pylinkage/mechanism/factories.py
@@ -30,22 +30,25 @@ def fourbar(
     Ground pivots are placed at ``A = (0, 0)`` and ``D = (ground, 0)``.
     The crank rotates about ``A`` and the rocker oscillates about ``D``.
 
-    :param crank: Crank length (link a, ``A``-``B``).
-    :param coupler: Coupler length (link b, ``B``-``C``).
-    :param rocker: Rocker length (link c, ``C``-``D``).
-    :param ground: Ground link length (link d, ``A``-``D``).
-    :param omega: Driver angular velocity, in rad/step.
-    :param initial_angle: Starting crank angle, in radians.
-    :param branch: ``0`` or ``1`` — which of the two circle-circle
-        intersections to pick for the coupler-rocker joint. Branch
-        ``1`` (default) is the upper (positive y) configuration,
-        matching ``synthesis.fourbar_from_lengths``.
-    :param name: Name of the resulting mechanism.
+    Args:
+        crank: Crank length (link a, ``A``-``B``).
+        coupler: Coupler length (link b, ``B``-``C``).
+        rocker: Rocker length (link c, ``C``-``D``).
+        ground: Ground link length (link d, ``A``-``D``).
+        omega: Driver angular velocity, in rad/step.
+        initial_angle: Starting crank angle, in radians.
+        branch: ``0`` or ``1`` — which of the two circle-circle
+            intersections to pick for the coupler-rocker joint. Branch
+            ``1`` (default) is the upper (positive y) configuration,
+            matching ``synthesis.fourbar_from_lengths``.
+        name: Name of the resulting mechanism.
 
-    :returns: An assembled :class:`Mechanism`.
+    Returns:
+        An assembled :class:`Mechanism`.
 
-    :raises pylinkage.exceptions.UnbuildableError: if the link lengths
-        cannot form a closed loop at ``initial_angle``.
+    Raises:
+        pylinkage.exceptions.UnbuildableError: if the link lengths
+            cannot form a closed loop at ``initial_angle``.
 
     Example:
         >>> from pylinkage.mechanism import fourbar
@@ -82,15 +85,17 @@ def slider_crank(
     of length ``rod`` whose far end slides along the line through
     ``slide_through`` in direction ``slide_direction``.
 
-    :param crank: Crank length.
-    :param rod: Connecting rod length.
-    :param omega: Driver angular velocity, in rad/step.
-    :param initial_angle: Starting crank angle, in radians.
-    :param slide_through: A point the slide axis passes through.
-    :param slide_direction: Direction vector of the slide axis.
-    :param name: Name of the resulting mechanism.
+    Args:
+        crank: Crank length.
+        rod: Connecting rod length.
+        omega: Driver angular velocity, in rad/step.
+        initial_angle: Starting crank angle, in radians.
+        slide_through: A point the slide axis passes through.
+        slide_direction: Direction vector of the slide axis.
+        name: Name of the resulting mechanism.
 
-    :returns: An assembled :class:`Mechanism`.
+    Returns:
+        An assembled :class:`Mechanism`.
 
     Example:
         >>> from pylinkage.mechanism import slider_crank

--- a/src/pylinkage/optimization/async_optimization.py
+++ b/src/pylinkage/optimization/async_optimization.py
@@ -76,33 +76,36 @@ async def particle_swarm_optimization_async(
     blocking the event loop, while providing progress callbacks and cancellation
     support.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-        The swarm will look for the HIGHEST score.
-    :param linkage: Linkage to be optimized.
-    :param center: A list of initial dimensions. If None, dimensions will be
-        generated randomly between bounds. The default is None.
-    :param dimensions: Number of dimensions of the swarm space.
-        If None, it takes len(tuple(linkage.get_constraints())).
-    :param n_particles: Number of particles in the swarm. The default is 100.
-    :param inertia: Inertia of each particle. The default is 0.6.
-    :param leader: Learning coefficient of each particle. The default is 3.0.
-    :param follower: Social coefficient. The default is 0.1.
-    :param neighbors: Number of neighbors to consider. The default is 17.
-    :param iterations: Number of iterations. The default is 200.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param on_progress: Optional callback function called with progress updates.
-        The callback receives an OptimizationProgress object.
-    :param executor: Optional ThreadPoolExecutor to use. If None, a default
-        executor will be created.
-    :param kwargs: Additional keyword arguments passed to LocalBestPSO.
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+            The swarm will look for the HIGHEST score.
+        linkage: Linkage to be optimized.
+        center: A list of initial dimensions. If None, dimensions will be
+            generated randomly between bounds. The default is None.
+        dimensions: Number of dimensions of the swarm space.
+            If None, it takes len(tuple(linkage.get_constraints())).
+        n_particles: Number of particles in the swarm. The default is 100.
+        inertia: Inertia of each particle. The default is 0.6.
+        leader: Learning coefficient of each particle. The default is 3.0.
+        follower: Social coefficient. The default is 0.1.
+        neighbors: Number of neighbors to consider. The default is 17.
+        iterations: Number of iterations. The default is 200.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+        order_relation: How to compare scores (max or min). Default is max.
+        on_progress: Optional callback function called with progress updates.
+            The callback receives an OptimizationProgress object.
+        executor: Optional ThreadPoolExecutor to use. If None, a default
+            executor will be created.
+        kwargs: Additional keyword arguments passed to LocalBestPSO.
 
-    :returns: List of Agents: best score, best dimensions and initial positions.
+    Returns:
+        List of Agents: best score, best dimensions and initial positions.
 
-    :raises asyncio.CancelledError: If the optimization is cancelled.
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        asyncio.CancelledError: If the optimization is cancelled.
+        OptimizationError: If parameters are invalid or optimization fails.
 
     Example::
 
@@ -192,26 +195,29 @@ async def trials_and_errors_optimization_async(
     to avoid blocking the event loop, while providing progress callbacks and
     cancellation support.
 
-    :param eval_func: Evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-    :param linkage: Linkage to evaluate.
-    :param parameters: Parameters that will be modified. If None, uses
-        tuple(linkage.get_constraints()).
-    :param n_results: Number of best candidates to return. The default is 10.
-    :param divisions: Number of subdivisions between bounds. The default is 5.
-    :param on_progress: Optional callback function called with progress updates.
-    :param executor: Optional ThreadPoolExecutor to use. If None, a default
-        executor will be created.
-    :param kwargs: Additional arguments for the optimization:
-        - bounds: A 2-tuple containing minimal and maximal bounds.
-        - order_relation: Function to compare scores (max, min, abs).
-        - sequential: If True, consecutive linkages have small variation.
+    Args:
+        eval_func: Evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+        linkage: Linkage to evaluate.
+        parameters: Parameters that will be modified. If None, uses
+            tuple(linkage.get_constraints()).
+        n_results: Number of best candidates to return. The default is 10.
+        divisions: Number of subdivisions between bounds. The default is 5.
+        on_progress: Optional callback function called with progress updates.
+        executor: Optional ThreadPoolExecutor to use. If None, a default
+            executor will be created.
+        kwargs: Additional arguments for the optimization:
+            - bounds: A 2-tuple containing minimal and maximal bounds.
+            - order_relation: Function to compare scores (max, min, abs).
+            - sequential: If True, consecutive linkages have small variation.
 
-    :returns: List of (score, dimensions, initial_position) tuples.
+    Returns:
+        List of (score, dimensions, initial_position) tuples.
 
-    :raises asyncio.CancelledError: If the optimization is cancelled.
-    :raises OptimizationError: If parameters are invalid or no valid solution found.
+    Raises:
+        asyncio.CancelledError: If the optimization is cancelled.
+        OptimizationError: If parameters are invalid or no valid solution found.
 
     Example::
 
@@ -302,27 +308,30 @@ async def differential_evolution_optimization_async(
     executor to avoid blocking the event loop, while providing progress callbacks
     and cancellation support.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-    :param linkage: Linkage to be optimized.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param strategy: Differential evolution strategy. Default is "best1bin".
-    :param maxiter: Maximum number of generations. Default is 1000.
-    :param popsize: Population size multiplier. Default is 15.
-    :param tol: Relative tolerance for convergence. Default is 0.01.
-    :param mutation: Mutation constant. Default is (0.5, 1.0).
-    :param recombination: Recombination constant. Default is 0.7.
-    :param seed: Random seed for reproducibility.
-    :param on_progress: Optional callback function called with progress updates.
-    :param executor: Optional ThreadPoolExecutor to use.
-    :param kwargs: Additional keyword arguments passed to differential_evolution.
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+        linkage: Linkage to be optimized.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+        order_relation: How to compare scores (max or min). Default is max.
+        strategy: Differential evolution strategy. Default is "best1bin".
+        maxiter: Maximum number of generations. Default is 1000.
+        popsize: Population size multiplier. Default is 15.
+        tol: Relative tolerance for convergence. Default is 0.01.
+        mutation: Mutation constant. Default is (0.5, 1.0).
+        recombination: Recombination constant. Default is 0.7.
+        seed: Random seed for reproducibility.
+        on_progress: Optional callback function called with progress updates.
+        executor: Optional ThreadPoolExecutor to use.
+        kwargs: Additional keyword arguments passed to differential_evolution.
 
-    :returns: List containing single Agent with best score, dimensions, and positions.
+    Returns:
+        List containing single Agent with best score, dimensions, and positions.
 
-    :raises asyncio.CancelledError: If the optimization is cancelled.
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        asyncio.CancelledError: If the optimization is cancelled.
+        OptimizationError: If parameters are invalid or optimization fails.
     """
     loop = asyncio.get_running_loop()
 
@@ -397,24 +406,27 @@ async def minimize_linkage_async(
     blocking the event loop, while providing progress callbacks and cancellation
     support.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-    :param linkage: Linkage to be optimized.
-    :param x0: Initial guess for the parameters.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param method: Optimization method. Default is "Nelder-Mead".
-    :param maxiter: Maximum number of iterations.
-    :param tol: Tolerance for termination.
-    :param on_progress: Optional callback function called with progress updates.
-    :param executor: Optional ThreadPoolExecutor to use.
-    :param kwargs: Additional keyword arguments passed to minimize.
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+        linkage: Linkage to be optimized.
+        x0: Initial guess for the parameters.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+        order_relation: How to compare scores (max or min). Default is max.
+        method: Optimization method. Default is "Nelder-Mead".
+        maxiter: Maximum number of iterations.
+        tol: Tolerance for termination.
+        on_progress: Optional callback function called with progress updates.
+        executor: Optional ThreadPoolExecutor to use.
+        kwargs: Additional keyword arguments passed to minimize.
 
-    :returns: List containing single Agent with best score, dimensions, and positions.
+    Returns:
+        List containing single Agent with best score, dimensions, and positions.
 
-    :raises asyncio.CancelledError: If the optimization is cancelled.
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        asyncio.CancelledError: If the optimization is cancelled.
+        OptimizationError: If parameters are invalid or optimization fails.
     """
     loop = asyncio.get_running_loop()
 

--- a/src/pylinkage/optimization/grid_search.py
+++ b/src/pylinkage/optimization/grid_search.py
@@ -39,10 +39,13 @@ def sequential_variator(
     The coefficient is in order: middle → min (step 2), min → middle (step 2),
     middle → max (step 1), so that there is no huge variation.
 
-    :param center: Elements that should vary.
-    :param divisions: Number of subdivisions between `bounds`.
-    :param bounds: 2-uple of minimal then maximal bounds.
-    :returns: An iterable of all the dimension combinations.
+    Args:
+        center: Elements that should vary.
+        divisions: Number of subdivisions between `bounds`.
+        bounds: 2-uple of minimal then maximal bounds.
+
+    Returns:
+        An iterable of all the dimension combinations.
     """
     # In the first place, we go in decreasing order to lower bound
     fall = np.linspace(center, bounds[0], int(divisions / 2))
@@ -73,9 +76,12 @@ def fast_variator(
 
     Here the order in the variations is not important.
 
-    :param divisions: Number of subdivisions between `bounds`.
-    :param bounds: 2-uple of minimal then maximal bounds.
-    :returns: An iterable of all the dimension combinations.
+    Args:
+        divisions: Number of subdivisions between `bounds`.
+        bounds: 2-uple of minimal then maximal bounds.
+
+    Returns:
+        An iterable of all the dimension combinations.
     """
     lists = (
         iter(np.linspace(low, high, divisions))
@@ -98,30 +104,34 @@ def trials_and_errors_optimization(
     Each dimension set has a score. The returned Ensemble contains up to
     *n_results* members with the best scores (maximization by default).
 
-    :param eval_func: Evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-    :param linkage: Linkage to evaluate.
-    :param parameters: Parameters that will be modified. Geometric constraints.
-                       If not, it will be assigned tuple(linkage.get_constraints()).
-                       The default is None.
-    :param n_results: Number of the best candidates to return. The default is 10.
-    :param divisions: Number of subdivisions between bounds. The default is 5.
-    :param kwargs:
-        - Extra arguments for the optimization.
-        - bounds : A 2-uple (tuple of two elements), containing the minimal and maximal bounds.
-            If None, we will use parameters as a center.
-            (Default value = None).
-        - order_relation : A function of two arguments, should return the best score of two
-            scores. Common examples are `min`, `max`, `abs`.
-            (Default value = :func:`max`).
-        - verbose : The number of combinations will be printed in console if `True`.
-            (Default value = True).
-        - sequential : If True, two consecutive linkages will have a small variation.
+    Args:
+        eval_func: Evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+        linkage: Linkage to evaluate.
+        parameters: Parameters that will be modified. Geometric constraints.
+            If not, it will be assigned tuple(linkage.get_constraints()).
+            The default is None.
+        n_results: Number of the best candidates to return. The default is 10.
+        divisions: Number of subdivisions between bounds. The default is 5.
+        kwargs: Extra arguments for the optimization:
 
-    :returns: Ensemble with up to *n_results* members.
+            - ``bounds``: A 2-uple containing the minimal and maximal bounds.
+              If None, we will use parameters as a center.
+              (Default value = None).
+            - ``order_relation``: A function of two arguments, should return the
+              best score of two scores. Common examples are ``min``, ``max``,
+              ``abs``. (Default value = :func:`max`).
+            - ``verbose``: The number of combinations will be printed in console
+              if ``True``. (Default value = True).
+            - ``sequential``: If True, two consecutive linkages will have a
+              small variation.
 
-    :raises OptimizationError: If parameters are invalid or no valid solution is found.
+    Returns:
+        Ensemble with up to *n_results* members.
+
+    Raises:
+        OptimizationError: If parameters are invalid or no valid solution is found.
     """
     if n_results <= 0:
         raise OptimizationError(f"Number of results must be positive, got {n_results}")

--- a/src/pylinkage/optimization/particle_swarm.py
+++ b/src/pylinkage/optimization/particle_swarm.py
@@ -42,21 +42,24 @@ def _local_best_pso(
     *k* nearest ring-topology neighbors, preventing premature convergence
     to a single basin.
 
-    :param objective: Function mapping (n_particles, dimensions) array to
-        (n_particles,) array of **costs to minimize**.
-    :param dimensions: Number of parameters.
-    :param bounds: ``(lower, upper)`` arrays each of shape ``(dimensions,)``.
-    :param n_particles: Swarm size.
-    :param inertia: Velocity damping factor *w*.
-    :param c1: Cognitive (personal-best) acceleration coefficient.
-    :param c2: Social (neighborhood-best) acceleration coefficient.
-    :param neighbors: Ring-topology neighborhood size *k*.
-    :param iterations: Number of iterations.
-    :param center: Center for initial position sampling. If ``None``, particles
-        are sampled uniformly within *bounds*; otherwise positions are concentrated
-        around the center point within bounds.
-    :param verbose: Print iteration progress.
-    :returns: ``(best_cost, best_position)``.
+    Args:
+        objective: Function mapping (n_particles, dimensions) array to
+            (n_particles,) array of **costs to minimize**.
+        dimensions: Number of parameters.
+        bounds: ``(lower, upper)`` arrays each of shape ``(dimensions,)``.
+        n_particles: Swarm size.
+        inertia: Velocity damping factor *w*.
+        c1: Cognitive (personal-best) acceleration coefficient.
+        c2: Social (neighborhood-best) acceleration coefficient.
+        neighbors: Ring-topology neighborhood size *k*.
+        iterations: Number of iterations.
+        center: Center for initial position sampling. If ``None``, particles
+            are sampled uniformly within *bounds*; otherwise positions are concentrated
+            around the center point within bounds.
+        verbose: Print iteration progress.
+
+    Returns:
+        ``(best_cost, best_position)``.
     """
     lb, ub = bounds
     rng = np.random.default_rng()
@@ -162,35 +165,38 @@ def particle_swarm_optimization(
 
     Uses a local-best ring-topology PSO implemented in pure NumPy.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-        The swarm will look for the HIGHEST score.
-    :param linkage: Linkage to be optimized. Make sure to give an optimized linkage for
-        better results.
-    :param center: A list of initial dimensions. If None, dimensions will be generated
-        randomly between bounds. The default is None.
-    :param dimensions: Number of dimensions of the swarm space, number of parameters.
-        If None, it takes the value len(tuple(linkage.get_constraints())).
-        The default is None.
-    :param n_particles: Number of particles in the swarm. The default is 100.
-    :param inertia: Inertia of each particle. The default is 0.6.
-    :param leader: Cognitive acceleration coefficient (c1). The default is 3.0.
-    :param follower: Social acceleration coefficient (c2). The default is 0.1.
-    :param neighbors: Number of neighbors in ring topology. The default is 17.
-    :param iterations: Number of iterations. The default is 200.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-        (Default value = None).
-    :param order_relation: How to compare scores.
-        There should not be anything else than the built-in
-        max and min functions.
-        The default is max.
-    :param verbose: The optimization state will be printed in the console if True.
-        (Default value = True).
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+            The swarm will look for the HIGHEST score.
+        linkage: Linkage to be optimized. Make sure to give an optimized linkage for
+            better results.
+        center: A list of initial dimensions. If None, dimensions will be generated
+            randomly between bounds. The default is None.
+        dimensions: Number of dimensions of the swarm space, number of parameters.
+            If None, it takes the value len(tuple(linkage.get_constraints())).
+            The default is None.
+        n_particles: Number of particles in the swarm. The default is 100.
+        inertia: Inertia of each particle. The default is 0.6.
+        leader: Cognitive acceleration coefficient (c1). The default is 3.0.
+        follower: Social acceleration coefficient (c2). The default is 0.1.
+        neighbors: Number of neighbors in ring topology. The default is 17.
+        iterations: Number of iterations. The default is 200.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+            (Default value = None).
+        order_relation: How to compare scores.
+            There should not be anything else than the built-in
+            max and min functions.
+            The default is max.
+        verbose: The optimization state will be printed in the console if True.
+            (Default value = True).
 
-    :returns: Ensemble with the best result (single member).
+    Returns:
+        Ensemble with the best result (single member).
 
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        OptimizationError: If parameters are invalid or optimization fails.
     """
     # Backwards-compatible alias
     if "iters" in kwargs:

--- a/src/pylinkage/optimization/scipy_optimize.py
+++ b/src/pylinkage/optimization/scipy_optimize.py
@@ -69,34 +69,37 @@ def differential_evolution_optimization(
     gradient information. It is generally faster than grid search and
     can handle multimodal objective functions.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-        The optimizer will look for the score based on order_relation.
-    :param linkage: Linkage to be optimized.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-        If None, bounds will be generated from linkage constraints using
-        generate_bounds().
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param strategy: Differential evolution strategy. Options include:
-        'best1bin', 'best1exp', 'rand1exp', 'randtobest1exp', 'best2exp',
-        'rand2exp', 'randtobest1bin', 'best2bin', 'rand2bin', 'rand1bin'.
-        Default is "best1bin".
-    :param maxiter: Maximum number of generations. Default is 1000.
-    :param popsize: Population size multiplier. The total population will be
-        popsize * dimensions. Default is 15.
-    :param tol: Relative tolerance for convergence. Default is 0.01.
-    :param mutation: Mutation constant (dithering). Can be a float in [0, 2]
-        or a tuple (min, max). Default is (0.5, 1.0).
-    :param recombination: Recombination constant in [0, 1]. Default is 0.7.
-    :param seed: Random seed for reproducibility.
-    :param workers: Number of parallel workers. Use -1 for all CPUs. Default is 1.
-    :param verbose: Print progress if True. Default is True.
-    :param kwargs: Additional keyword arguments passed to differential_evolution.
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+            The optimizer will look for the score based on order_relation.
+        linkage: Linkage to be optimized.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+            If None, bounds will be generated from linkage constraints using
+            generate_bounds().
+        order_relation: How to compare scores (max or min). Default is max.
+        strategy: Differential evolution strategy. Options include:
+            'best1bin', 'best1exp', 'rand1exp', 'randtobest1exp', 'best2exp',
+            'rand2exp', 'randtobest1bin', 'best2bin', 'rand2bin', 'rand1bin'.
+            Default is "best1bin".
+        maxiter: Maximum number of generations. Default is 1000.
+        popsize: Population size multiplier. The total population will be
+            popsize * dimensions. Default is 15.
+        tol: Relative tolerance for convergence. Default is 0.01.
+        mutation: Mutation constant (dithering). Can be a float in [0, 2]
+            or a tuple (min, max). Default is (0.5, 1.0).
+        recombination: Recombination constant in [0, 1]. Default is 0.7.
+        seed: Random seed for reproducibility.
+        workers: Number of parallel workers. Use -1 for all CPUs. Default is 1.
+        verbose: Print progress if True. Default is True.
+        kwargs: Additional keyword arguments passed to differential_evolution.
 
-    :returns: Ensemble with the best result (single member).
+    Returns:
+        Ensemble with the best result (single member).
 
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        OptimizationError: If parameters are invalid or optimization fails.
 
     Example::
 
@@ -204,29 +207,32 @@ def dual_annealing_optimization(
     with controlled random jumps, making it effective for problems with many
     local minima and expensive evaluations.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-    :param linkage: Linkage to be optimized.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-        If None, bounds will be generated from linkage constraints.
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param maxiter: Maximum number of global iterations. Default is 1000.
-    :param initial_temp: Initial temperature for the annealing schedule.
-        Higher values allow more exploration. Default is 5230.0.
-    :param restart_temp_ratio: Fraction of initial_temp at which the
-        temperature is restarted. Default is 2e-5.
-    :param visit: Parameter for the visiting distribution. Higher values
-        give heavier tails (more long-range jumps). Default is 2.62.
-    :param accept: Parameter for the acceptance distribution. Lower values
-        make acceptance more restrictive. Default is -5.0.
-    :param seed: Random seed for reproducibility.
-    :param verbose: Print progress if True. Default is True.
-    :param kwargs: Additional keyword arguments passed to dual_annealing.
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+        linkage: Linkage to be optimized.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+            If None, bounds will be generated from linkage constraints.
+        order_relation: How to compare scores (max or min). Default is max.
+        maxiter: Maximum number of global iterations. Default is 1000.
+        initial_temp: Initial temperature for the annealing schedule.
+            Higher values allow more exploration. Default is 5230.0.
+        restart_temp_ratio: Fraction of initial_temp at which the
+            temperature is restarted. Default is 2e-5.
+        visit: Parameter for the visiting distribution. Higher values
+            give heavier tails (more long-range jumps). Default is 2.62.
+        accept: Parameter for the acceptance distribution. Lower values
+            make acceptance more restrictive. Default is -5.0.
+        seed: Random seed for reproducibility.
+        verbose: Print progress if True. Default is True.
+        kwargs: Additional keyword arguments passed to dual_annealing.
 
-    :returns: Ensemble with the best result (single member).
+    Returns:
+        Ensemble with the best result (single member).
 
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        OptimizationError: If parameters are invalid or optimization fails.
 
     Example::
 
@@ -334,32 +340,35 @@ def minimize_linkage(
     scipy's minimize function. It supports various gradient-free methods
     suitable for linkage optimization.
 
-    :param eval_func: The evaluation function.
-        Input: (linkage, num_constraints, initial_coordinates).
-        Output: score (float).
-        The optimizer will look for the score based on order_relation.
-    :param linkage: Linkage to be optimized.
-    :param x0: Initial guess for the parameters. If None, uses current
-        linkage constraints.
-    :param bounds: Bounds to the space, in format (lower_bound, upper_bound).
-        If None and method supports bounds, bounds will be generated from
-        linkage constraints.
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param method: Optimization method. Options:
-        - "Nelder-Mead": Simplex method, no bounds (default)
-        - "Powell": Powell's method, no bounds
-        - "COBYLA": Constrained optimization by linear approximation
-        - "L-BFGS-B": Limited-memory BFGS with bounds
-        - "SLSQP": Sequential Least Squares Programming
-        - "TNC": Truncated Newton with bounds
-    :param maxiter: Maximum number of iterations. If None, uses scipy default.
-    :param tol: Tolerance for termination. If None, uses scipy default.
-    :param verbose: Print progress if True. Default is True.
-    :param kwargs: Additional keyword arguments passed to minimize.
+    Args:
+        eval_func: The evaluation function.
+            Input: (linkage, num_constraints, initial_coordinates).
+            Output: score (float).
+            The optimizer will look for the score based on order_relation.
+        linkage: Linkage to be optimized.
+        x0: Initial guess for the parameters. If None, uses current
+            linkage constraints.
+        bounds: Bounds to the space, in format (lower_bound, upper_bound).
+            If None and method supports bounds, bounds will be generated from
+            linkage constraints.
+        order_relation: How to compare scores (max or min). Default is max.
+        method: Optimization method. Options:
+            - "Nelder-Mead": Simplex method, no bounds (default)
+            - "Powell": Powell's method, no bounds
+            - "COBYLA": Constrained optimization by linear approximation
+            - "L-BFGS-B": Limited-memory BFGS with bounds
+            - "SLSQP": Sequential Least Squares Programming
+            - "TNC": Truncated Newton with bounds
+        maxiter: Maximum number of iterations. If None, uses scipy default.
+        tol: Tolerance for termination. If None, uses scipy default.
+        verbose: Print progress if True. Default is True.
+        kwargs: Additional keyword arguments passed to minimize.
 
-    :returns: Ensemble with the best result (single member).
+    Returns:
+        Ensemble with the best result (single member).
 
-    :raises OptimizationError: If parameters are invalid or optimization fails.
+    Raises:
+        OptimizationError: If parameters are invalid or optimization fails.
 
     Example::
 
@@ -469,18 +478,21 @@ def chain_optimizers(
     starting point (via ``center`` for population-based methods, or ``x0``
     for local methods).
 
-    :param eval_func: The evaluation function, shared across all stages.
-    :param linkage: Linkage to be optimized.
-    :param stages: Sequence of ``(optimizer_func, kwargs)`` tuples. Each
-        ``optimizer_func`` must accept ``eval_func`` and ``linkage`` as
-        its first two positional arguments. ``kwargs`` are passed through.
-        Do **not** include ``eval_func`` or ``linkage`` in ``kwargs``.
-    :param order_relation: How to compare scores (max or min). Default is max.
-    :param verbose: Print stage headers and progress. Default is True.
+    Args:
+        eval_func: The evaluation function, shared across all stages.
+        linkage: Linkage to be optimized.
+        stages: Sequence of ``(optimizer_func, kwargs)`` tuples. Each
+            ``optimizer_func`` must accept ``eval_func`` and ``linkage`` as
+            its first two positional arguments. ``kwargs`` are passed through.
+            Do **not** include ``eval_func`` or ``linkage`` in ``kwargs``.
+        order_relation: How to compare scores (max or min). Default is max.
+        verbose: Print stage headers and progress. Default is True.
 
-    :returns: Ensemble from the final optimization stage.
+    Returns:
+        Ensemble from the final optimization stage.
 
-    :raises OptimizationError: If no stages are provided.
+    Raises:
+        OptimizationError: If no stages are provided.
 
     Example::
 

--- a/src/pylinkage/optimization/utils.py
+++ b/src/pylinkage/optimization/utils.py
@@ -27,15 +27,17 @@ def generate_bounds(
 ) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
     """Simple function to generate bounds from a linkage.
 
-    :param center: 1-D sequence, often in the form of ``linkage.get_constraints()``.
-    :param min_ratio: Minimal compression ratio for the bounds. Minimal bounds will be of the
-        shape center[x] / min_ratio.
-        (Default value = 5).
-    :param max_factor: Dilation factor for the upper bounds. Maximal bounds will be of the
-        shape center[x] * max_factor.
-        (Default value = 5).
+    Args:
+        center: 1-D sequence, often in the form of ``linkage.get_constraints()``.
+        min_ratio: Minimal compression ratio for the bounds. Minimal bounds will be of the
+            shape center[x] / min_ratio.
+            (Default value = 5).
+        max_factor: Dilation factor for the upper bounds. Maximal bounds will be of the
+            shape center[x] * max_factor.
+            (Default value = 5).
 
-    :raises OptimizationError: If min_ratio or max_factor are not positive.
+    Raises:
+        OptimizationError: If min_ratio or max_factor are not positive.
     """
     if min_ratio <= 0:
         raise OptimizationError(f"min_ratio must be positive, got {min_ratio}")
@@ -53,7 +55,8 @@ def kinematic_maximization(
     This decorator makes a kinematic simulation, before passing the loci to the
     decorated function. In case of error, the penalty value is -float('inf').
 
-    :param func: Fitness function to be decorated.
+    Args:
+        func: Fitness function to be decorated.
     """
     return kinematic_default_test(func, -float("inf"))
 
@@ -66,6 +69,7 @@ def kinematic_minimization(
     This decorator makes a kinematic simulation, before passing the loci to the
     decorated function. In case of error, the penalty value is float('inf').
 
-    :param func: Fitness function to be decorated.
+    Args:
+        func: Fitness function to be decorated.
     """
     return kinematic_default_test(func, float("inf"))

--- a/src/pylinkage/symbolic/conversion.py
+++ b/src/pylinkage/symbolic/conversion.py
@@ -20,8 +20,11 @@ def get_numeric_parameters(sym_linkage: SymbolicLinkage) -> dict[str, float]:
     Returns a ``{parameter_name: value}`` dict populated from
     ``_numeric_*`` attributes previously stashed on each joint.
 
-    :param sym_linkage: The symbolic linkage.
-    :returns: Dictionary mapping parameter names to numeric values.
+    Args:
+        sym_linkage: The symbolic linkage.
+
+    Returns:
+        Dictionary mapping parameter names to numeric values.
     """
     params: dict[str, float] = {}
 
@@ -56,13 +59,16 @@ def fourbar_symbolic(
     - B (crank end): Crank rotating around A with radius ``crank_length``
     - C (coupler/rocker connection): Revolute connecting B and D
 
-    :param ground_length: Distance between ground anchors A and D.
-    :param crank_length: Length of the input crank (A to B).
-    :param coupler_length: Length of the coupler (B to C).
-    :param rocker_length: Length of the output rocker (D to C).
-    :param ground_x: X coordinate of ground anchor A. Default is 0.
-    :param ground_y: Y coordinate of ground anchor A. Default is 0.
-    :returns: A SymbolicLinkage representing the four-bar.
+    Args:
+        ground_length: Distance between ground anchors A and D.
+        crank_length: Length of the input crank (A to B).
+        coupler_length: Length of the coupler (B to C).
+        rocker_length: Length of the output rocker (D to C).
+        ground_x: X coordinate of ground anchor A. Default is 0.
+        ground_y: Y coordinate of ground anchor A. Default is 0.
+
+    Returns:
+        A SymbolicLinkage representing the four-bar.
     """
     if isinstance(ground_length, str):
         L0 = sp.Symbol(ground_length, positive=True, real=True)

--- a/src/pylinkage/symbolic/geometry.py
+++ b/src/pylinkage/symbolic/geometry.py
@@ -18,11 +18,14 @@ def symbolic_dist(
     """
     Compute the symbolic Euclidean distance between two points.
 
-    :param x1: X coordinate of first point.
-    :param y1: Y coordinate of first point.
-    :param x2: X coordinate of second point.
-    :param y2: Y coordinate of second point.
-    :returns: Symbolic expression for the distance.
+    Args:
+        x1: X coordinate of first point.
+        y1: Y coordinate of first point.
+        x2: X coordinate of second point.
+        y2: Y coordinate of second point.
+
+    Returns:
+        Symbolic expression for the distance.
     """
     return sp.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
 
@@ -38,11 +41,14 @@ def symbolic_sqr_dist(
 
     Useful for avoiding square roots in constraint equations.
 
-    :param x1: X coordinate of first point.
-    :param y1: Y coordinate of first point.
-    :param x2: X coordinate of second point.
-    :param y2: Y coordinate of second point.
-    :returns: Symbolic expression for the squared distance.
+    Args:
+        x1: X coordinate of first point.
+        y1: Y coordinate of first point.
+        x2: X coordinate of second point.
+        y2: Y coordinate of second point.
+
+    Returns:
+        Symbolic expression for the squared distance.
     """
     return (x1 - x2) ** 2 + (y1 - y2) ** 2
 
@@ -56,11 +62,14 @@ def symbolic_cyl_to_cart(
     """
     Convert polar coordinates to cartesian coordinates symbolically.
 
-    :param radius: Distance from origin.
-    :param angle: Angle in radians (counterclockwise from positive x-axis).
-    :param ori_x: X coordinate of origin. Default is 0.
-    :param ori_y: Y coordinate of origin. Default is 0.
-    :returns: Tuple of (x, y) symbolic expressions.
+    Args:
+        radius: Distance from origin.
+        angle: Angle in radians (counterclockwise from positive x-axis).
+        ori_x: X coordinate of origin. Default is 0.
+        ori_y: Y coordinate of origin. Default is 0.
+
+    Returns:
+        Tuple of (x, y) symbolic expressions.
     """
     ori_x = sp.sympify(ori_x)
     ori_y = sp.sympify(ori_y)
@@ -94,15 +103,18 @@ def symbolic_circle_intersect(
     - The intersection points are at distance h perpendicular to the line
       connecting the centers.
 
-    :param x1: X coordinate of first circle center.
-    :param y1: Y coordinate of first circle center.
-    :param r1: Radius of first circle.
-    :param x2: X coordinate of second circle center.
-    :param y2: Y coordinate of second circle center.
-    :param r2: Radius of second circle.
-    :param branch: +1 or -1 to select which intersection point.
-        Default is +1.
-    :returns: Tuple of (x, y) symbolic expressions for the intersection.
+    Args:
+        x1: X coordinate of first circle center.
+        y1: Y coordinate of first circle center.
+        r1: Radius of first circle.
+        x2: X coordinate of second circle center.
+        y2: Y coordinate of second circle center.
+        r2: Radius of second circle.
+        branch: +1 or -1 to select which intersection point.
+            Default is +1.
+
+    Returns:
+        Tuple of (x, y) symbolic expressions for the intersection.
 
     Note:
         The expressions may be complex (imaginary) for parameter values
@@ -154,16 +166,19 @@ def symbolic_circle_line_intersect(
     The line is defined by two points on it. The branch parameter
     selects which of the two intersection points to return.
 
-    :param cx: X coordinate of circle center.
-    :param cy: Y coordinate of circle center.
-    :param r: Radius of the circle.
-    :param p1_x: X coordinate of first point on line.
-    :param p1_y: Y coordinate of first point on line.
-    :param p2_x: X coordinate of second point on line.
-    :param p2_y: Y coordinate of second point on line.
-    :param branch: +1 or -1 to select which intersection point.
-        Default is +1.
-    :returns: Tuple of (x, y) symbolic expressions for the intersection.
+    Args:
+        cx: X coordinate of circle center.
+        cy: Y coordinate of circle center.
+        r: Radius of the circle.
+        p1_x: X coordinate of first point on line.
+        p1_y: Y coordinate of first point on line.
+        p2_x: X coordinate of second point on line.
+        p2_y: Y coordinate of second point on line.
+        branch: +1 or -1 to select which intersection point.
+            Default is +1.
+
+    Returns:
+        Tuple of (x, y) symbolic expressions for the intersection.
 
     Note:
         The expressions may be complex (imaginary) for parameter values

--- a/src/pylinkage/symbolic/joints.py
+++ b/src/pylinkage/symbolic/joints.py
@@ -49,11 +49,12 @@ class SymJoint(abc.ABC):
         """
         Create a symbolic joint.
 
-        :param x: Initial or symbolic x position.
-        :param y: Initial or symbolic y position.
-        :param parent0: First parent joint (for kinematic constraints).
-        :param parent1: Second parent joint (for kinematic constraints).
-        :param name: Human-readable name for the joint.
+        Args:
+            x: Initial or symbolic x position.
+            y: Initial or symbolic y position.
+            parent0: First parent joint (for kinematic constraints).
+            parent1: Second parent joint (for kinematic constraints).
+            name: Human-readable name for the joint.
         """
         self._x = sp.sympify(x) if x is not None else None
         self._y = sp.sympify(y) if y is not None else None
@@ -70,7 +71,8 @@ class SymJoint(abc.ABC):
         """
         Return the symbolic (x, y) position expressions.
 
-        :returns: Tuple of (x_expr, y_expr) SymPy expressions.
+        Returns:
+            Tuple of (x_expr, y_expr) SymPy expressions.
         """
         raise NotImplementedError
 
@@ -79,7 +81,8 @@ class SymJoint(abc.ABC):
         """
         Return the constraint equations this joint satisfies.
 
-        :returns: List of SymPy Eq objects representing constraints.
+        Returns:
+            List of SymPy Eq objects representing constraints.
         """
         raise NotImplementedError
 
@@ -90,7 +93,8 @@ class SymJoint(abc.ABC):
 
         Excludes the input angle theta.
 
-        :returns: Set of SymPy symbols that are parameters.
+        Returns:
+            Set of SymPy symbols that are parameters.
         """
         x_expr, y_expr = self.position_expr()
         all_symbols = x_expr.free_symbols | y_expr.free_symbols
@@ -118,9 +122,10 @@ class SymStatic(SymJoint):
         """
         Create a static joint at a fixed position.
 
-        :param x: X coordinate (numeric or symbolic). Default is 0.
-        :param y: Y coordinate (numeric or symbolic). Default is 0.
-        :param name: Human-readable name for the joint.
+        Args:
+            x: X coordinate (numeric or symbolic). Default is 0.
+            y: Y coordinate (numeric or symbolic). Default is 0.
+            name: Human-readable name for the joint.
         """
         super().__init__(x=x, y=y, name=name)
 
@@ -159,11 +164,12 @@ class SymCrank(SymJoint):
         """
         Create a crank joint rotating around a parent.
 
-        :param parent: Parent joint or fixed coordinate (x, y).
-        :param radius: Distance from parent. Can be numeric, symbolic, or
-            a string to create a new symbol. Default is "r".
-        :param theta: Input angle symbol. Default uses the global theta.
-        :param name: Human-readable name for the joint.
+        Args:
+            parent: Parent joint or fixed coordinate (x, y).
+            radius: Distance from parent. Can be numeric, symbolic, or
+                a string to create a new symbol. Default is "r".
+            theta: Input angle symbol. Default uses the global theta.
+            name: Human-readable name for the joint.
         """
         if isinstance(parent, SymJoint):
             super().__init__(parent0=parent, name=name)
@@ -253,15 +259,16 @@ class SymRevolute(SymJoint):
         """
         Create a revolute joint connecting two parents.
 
-        :param parent0: First parent joint.
-        :param parent1: Second parent joint.
-        :param distance0: Distance to parent0. Can be numeric, symbolic, or
-            a string to create a new symbol. Default is "r0".
-        :param distance1: Distance to parent1. Can be numeric, symbolic, or
-            a string to create a new symbol. Default is "r1".
-        :param branch: +1 or -1 to select which circle intersection.
-            Default is +1.
-        :param name: Human-readable name for the joint.
+        Args:
+            parent0: First parent joint.
+            parent1: Second parent joint.
+            distance0: Distance to parent0. Can be numeric, symbolic, or
+                a string to create a new symbol. Default is "r0".
+            distance1: Distance to parent1. Can be numeric, symbolic, or
+                a string to create a new symbol. Default is "r1".
+            branch: +1 or -1 to select which circle intersection.
+                Default is +1.
+            name: Human-readable name for the joint.
         """
         super().__init__(parent0=parent0, parent1=parent1, name=name)
 

--- a/src/pylinkage/symbolic/linkage.py
+++ b/src/pylinkage/symbolic/linkage.py
@@ -43,9 +43,10 @@ class SymbolicLinkage:
         """
         Create a symbolic linkage from a collection of joints.
 
-        :param joints: Iterable of SymJoint objects.
-        :param theta: Input angle symbol. Default uses the global theta.
-        :param name: Human-readable name for the linkage.
+        Args:
+            joints: Iterable of SymJoint objects.
+            theta: Input angle symbol. Default uses the global theta.
+            name: Human-readable name for the linkage.
         """
         self.joints = tuple(joints)
         self.theta = theta if theta is not None else default_theta
@@ -65,7 +66,8 @@ class SymbolicLinkage:
         Collects parameters from all joints and returns them as a
         dictionary mapping parameter names to symbols.
 
-        :returns: Dictionary of parameter name to symbol.
+        Returns:
+            Dictionary of parameter name to symbol.
         """
         if self._parameters is None:
             self._parameters = {}
@@ -78,9 +80,14 @@ class SymbolicLinkage:
         """
         Get a joint by name.
 
-        :param name: Name of the joint.
-        :returns: The joint with the given name.
-        :raises ValueError: If no joint with the given name exists.
+        Args:
+            name: Name of the joint.
+
+        Returns:
+            The joint with the given name.
+
+        Raises:
+            ValueError: If no joint with the given name exists.
         """
         for joint in self.joints:
             if joint.name == name:
@@ -91,7 +98,8 @@ class SymbolicLinkage:
         """
         Return symbolic trajectory expressions for all joints.
 
-        :returns: Dictionary mapping joint name to (x(theta), y(theta)).
+        Returns:
+            Dictionary mapping joint name to (x(theta), y(theta)).
         """
         return {joint.name: joint.position_expr() for joint in self.joints}
 
@@ -99,7 +107,8 @@ class SymbolicLinkage:
         """
         Return all constraint equations for the linkage.
 
-        :returns: List of SymPy Eq objects representing all constraints.
+        Returns:
+            List of SymPy Eq objects representing all constraints.
         """
         equations: list[sp.Eq] = []
         for joint in self.joints:
@@ -110,9 +119,14 @@ class SymbolicLinkage:
         """
         Get the trajectory expression for a specific joint.
 
-        :param joint_name: Name of the joint.
-        :returns: Tuple of (x(theta), y(theta)) expressions.
-        :raises ValueError: If no joint with the given name exists.
+        Args:
+            joint_name: Name of the joint.
+
+        Returns:
+            Tuple of (x(theta), y(theta)) expressions.
+
+        Raises:
+            ValueError: If no joint with the given name exists.
         """
         joint = self.get_joint(joint_name)
         return joint.position_expr()
@@ -128,9 +142,12 @@ class SymbolicLinkage:
         each parameter. This is useful for sensitivity analysis and
         gradient-based optimization.
 
-        :param joint_names: List of joint names to include. If None, all
-            joints are included.
-        :returns: SymPy Matrix of shape (2*n_joints, n_params).
+        Args:
+            joint_names: List of joint names to include. If None, all
+                joints are included.
+
+        Returns:
+            SymPy Matrix of shape (2*n_joints, n_params).
         """
         if joint_names is None:
             joints_to_include = self.joints
@@ -159,9 +176,12 @@ class SymbolicLinkage:
 
         This gives the velocity direction for each joint.
 
-        :param joint_names: List of joint names to include. If None, all
-            joints are included.
-        :returns: SymPy Matrix of shape (2*n_joints, 1).
+        Args:
+            joint_names: List of joint names to include. If None, all
+                joints are included.
+
+        Returns:
+            SymPy Matrix of shape (2*n_joints, 1).
         """
         if joint_names is None:
             joints_to_include = self.joints
@@ -185,7 +205,8 @@ class SymbolicLinkage:
         Note: This creates new joint objects with simplified expressions,
         but the linkage structure is preserved.
 
-        :returns: New SymbolicLinkage with simplified position expressions.
+        Returns:
+            New SymbolicLinkage with simplified position expressions.
         """
         from .joints import SymCrank, SymRevolute, SymStatic
 
@@ -246,8 +267,11 @@ class SymbolicLinkage:
         This is useful for partial evaluation or for substituting
         symbolic parameters with numeric values.
 
-        :param param_values: Dictionary mapping parameter names to values.
-        :returns: New SymbolicLinkage with substituted parameters.
+        Args:
+            param_values: Dictionary mapping parameter names to values.
+
+        Returns:
+            New SymbolicLinkage with substituted parameters.
         """
         from .joints import SymCrank, SymRevolute, SymStatic
 

--- a/src/pylinkage/symbolic/optimization.py
+++ b/src/pylinkage/symbolic/optimization.py
@@ -27,9 +27,12 @@ def symbolic_gradient(
     """
     Compute the symbolic gradient of an objective function.
 
-    :param objective: Symbolic objective expression.
-    :param parameters: List of parameter symbols to differentiate with respect to.
-    :returns: List of partial derivative expressions.
+    Args:
+        objective: Symbolic objective expression.
+        parameters: List of parameter symbols to differentiate with respect to.
+
+    Returns:
+        List of partial derivative expressions.
     """
     return [sp.diff(objective, p) for p in parameters]
 
@@ -41,9 +44,12 @@ def symbolic_hessian(
     """
     Compute the symbolic Hessian matrix of an objective function.
 
-    :param objective: Symbolic objective expression.
-    :param parameters: List of parameter symbols.
-    :returns: SymPy Matrix of second partial derivatives.
+    Args:
+        objective: Symbolic objective expression.
+        parameters: List of parameter symbols.
+
+    Returns:
+        SymPy Matrix of second partial derivatives.
     """
     return sp.hessian(objective, parameters)
 
@@ -97,13 +103,14 @@ class SymbolicOptimizer:
         """
         Create a symbolic optimizer.
 
-        :param linkage: The symbolic linkage to optimize.
-        :param objective_func: Function that takes trajectory dict and returns
-            a symbolic objective expression. The trajectories are
-            {joint_name: (x_expr, y_expr)} where x_expr and y_expr are
-            symbolic expressions in theta and parameters.
-        :param theta_samples: Number of theta samples for averaging objectives
-            that depend on the full trajectory. Default is 360.
+        Args:
+            linkage: The symbolic linkage to optimize.
+            objective_func: Function that takes trajectory dict and returns
+                a symbolic objective expression. The trajectories are
+                {joint_name: (x_expr, y_expr)} where x_expr and y_expr are
+                symbolic expressions in theta and parameters.
+            theta_samples: Number of theta samples for averaging objectives
+                that depend on the full trajectory. Default is 360.
         """
         self.linkage = linkage
         self.objective_func = objective_func
@@ -146,10 +153,13 @@ class SymbolicOptimizer:
 
         The objective is averaged over all theta samples.
 
-        :param param_values: Dictionary mapping parameter names to values.
-        :param theta_samples: Theta values to evaluate at. If None, uses
-            equally spaced samples over [0, 2*pi].
-        :returns: Mean objective value.
+        Args:
+            param_values: Dictionary mapping parameter names to values.
+            theta_samples: Theta values to evaluate at. If None, uses
+                equally spaced samples over [0, 2*pi].
+
+        Returns:
+            Mean objective value.
         """
         if theta_samples is None:
             theta_samples = np.linspace(0, 2 * np.pi, self.theta_samples)
@@ -186,10 +196,13 @@ class SymbolicOptimizer:
 
         The gradient is averaged over all theta samples.
 
-        :param param_values: Dictionary mapping parameter names to values.
-        :param theta_samples: Theta values to evaluate at. If None, uses
-            equally spaced samples over [0, 2*pi].
-        :returns: Array of gradient values (one per parameter).
+        Args:
+            param_values: Dictionary mapping parameter names to values.
+            theta_samples: Theta values to evaluate at. If None, uses
+                equally spaced samples over [0, 2*pi].
+
+        Returns:
+            Array of gradient values (one per parameter).
         """
         if theta_samples is None:
             theta_samples = np.linspace(0, 2 * np.pi, self.theta_samples)
@@ -235,14 +248,17 @@ class SymbolicOptimizer:
 
         Uses scipy.optimize.minimize with analytical gradients.
 
-        :param initial_params: Dictionary of initial parameter values.
-        :param bounds: Dictionary mapping parameter names to (min, max) bounds.
-            If None, parameters are unbounded.
-        :param theta_samples: Theta values for objective evaluation.
-        :param method: Scipy optimization method. Default is "L-BFGS-B".
-        :param maxiter: Maximum iterations. Default is 1000.
-        :param tol: Convergence tolerance. Default is 1e-6.
-        :returns: OptimizationResult with optimal parameters.
+        Args:
+            initial_params: Dictionary of initial parameter values.
+            bounds: Dictionary mapping parameter names to (min, max) bounds.
+                If None, parameters are unbounded.
+            theta_samples: Theta values for objective evaluation.
+            method: Scipy optimization method. Default is "L-BFGS-B".
+            maxiter: Maximum iterations. Default is 1000.
+            tol: Convergence tolerance. Default is 1e-6.
+
+        Returns:
+            OptimizationResult with optimal parameters.
         """
         from scipy.optimize import minimize
 
@@ -299,11 +315,14 @@ def generate_symbolic_bounds(
     Creates bounds as (center/min_ratio, center*max_factor) for each
     parameter. This is similar to the numeric generate_bounds function.
 
-    :param linkage: The symbolic linkage.
-    :param center_values: Dictionary of center values for each parameter.
-    :param min_ratio: Divisor for lower bound. Default is 5.
-    :param max_factor: Multiplier for upper bound. Default is 5.
-    :returns: Dictionary mapping parameter names to (min, max) bounds.
+    Args:
+        linkage: The symbolic linkage.
+        center_values: Dictionary of center values for each parameter.
+        min_ratio: Divisor for lower bound. Default is 5.
+        max_factor: Multiplier for upper bound. Default is 5.
+
+    Returns:
+        Dictionary mapping parameter names to (min, max) bounds.
     """
     bounds = {}
     for param_name in linkage.parameters:

--- a/src/pylinkage/symbolic/solver.py
+++ b/src/pylinkage/symbolic/solver.py
@@ -31,11 +31,14 @@ def solve_linkage_symbolically(
     Returns (optionally simplified) closed-form expressions for
     trajectory curves of all or specified joints.
 
-    :param linkage: The symbolic linkage to solve.
-    :param output_joints: List of joint names to include in output.
-        If None, all joints are included.
-    :param simplify: Whether to simplify the expressions. Default is True.
-    :returns: Dictionary mapping joint name to (x(theta), y(theta)).
+    Args:
+        linkage: The symbolic linkage to solve.
+        output_joints: List of joint names to include in output.
+            If None, all joints are included.
+        simplify: Whether to simplify the expressions. Default is True.
+
+    Returns:
+        Dictionary mapping joint name to (x(theta), y(theta)).
     """
     trajectories = linkage.get_trajectory_expressions()
 
@@ -67,10 +70,13 @@ def eliminate_theta(
     constraint c^2 + s^2 = 1, then eliminates c and s using
     Groebner basis.
 
-    :param x_expr: X coordinate as a function of theta.
-    :param y_expr: Y coordinate as a function of theta.
-    :param theta: The angle symbol to eliminate. Default uses global theta.
-    :returns: Polynomial in x and y, or None if elimination fails.
+    Args:
+        x_expr: X coordinate as a function of theta.
+        y_expr: Y coordinate as a function of theta.
+        theta: The angle symbol to eliminate. Default uses global theta.
+
+    Returns:
+        Polynomial in x and y, or None if elimination fails.
 
     Example:
         >>> theta = sp.Symbol('theta')
@@ -135,11 +141,14 @@ def compute_trajectory_numeric(
     Uses lambdify for efficient numeric evaluation of the symbolic
     trajectory expressions.
 
-    :param linkage: The symbolic linkage.
-    :param param_values: Dictionary mapping parameter names to numeric values.
-    :param theta_values: Sequence of theta values to evaluate at.
-    :param output_joints: List of joint names to include. If None, all joints.
-    :returns: Dictionary mapping joint name to Nx2 array of (x, y) positions.
+    Args:
+        linkage: The symbolic linkage.
+        param_values: Dictionary mapping parameter names to numeric values.
+        theta_values: Sequence of theta values to evaluate at.
+        output_joints: List of joint names to include. If None, all joints.
+
+    Returns:
+        Dictionary mapping joint name to Nx2 array of (x, y) positions.
     """
     theta_arr = np.asarray(theta_values, dtype=np.float64)
 
@@ -187,9 +196,12 @@ def create_trajectory_functions(
     This is useful when you need to evaluate trajectories many times
     with different parameter values, as it avoids repeated lambdify calls.
 
-    :param linkage: The symbolic linkage.
-    :param output_joints: List of joint names to include. If None, all joints.
-    :returns: Dictionary mapping joint name to (x_func, y_func, param_symbols).
+    Args:
+        linkage: The symbolic linkage.
+        output_joints: List of joint names to include. If None, all joints.
+
+    Returns:
+        Dictionary mapping joint name to (x_func, y_func, param_symbols).
 
     Example:
         >>> funcs = create_trajectory_functions(linkage)
@@ -226,10 +238,13 @@ def check_buildability(
     the positions at a specific theta and checks for complex (imaginary)
     results.
 
-    :param linkage: The symbolic linkage.
-    :param param_values: Dictionary mapping parameter names to numeric values.
-    :param theta_value: Theta value to check at. Default is 0.
-    :returns: Tuple of (is_buildable, error_message).
+    Args:
+        linkage: The symbolic linkage.
+        param_values: Dictionary mapping parameter names to numeric values.
+        theta_value: Theta value to check at. Default is 0.
+
+    Returns:
+        Tuple of (is_buildable, error_message).
 
     Example:
         >>> buildable, msg = check_buildability(linkage, {"r0": 1, "r1": 10})


### PR DESCRIPTION
Step one of the docstring cleanup. Google style chosen as the target: it is
where 85 of the 101 documented files already sat, napoleon is already enabled
for it, and it is the de facto default for new Python projects.

## What was inconsistent

| Style | Before | After |
|---|---:|---:|
| Google (`Args:`) | 85 files | **100 files** |
| reST field lists (`:param:`) | 16 files | **0** |

The 16 reST files were the oldest code in the package, concentrated in
`symbolic/` (all six modules), `optimization/` (five) and `geometry/`.
`linkage/transmission.py` used **both conventions in the same file** — `:param:`
at line 83, `Args:` at line 134.

## What changed

393 fields rewritten: 312 `:param:`, 63 `:returns:`/`:return:`, 18 `:raises:`.

Sphinx cross-reference roles (``:func:`max` ``, `` :class:`X` ``) are left alone —
84 of them across the codebase — since they are valid inside Google-style
docstrings.

## This is presentation only, and verified as such

Rather than trusting the conversion by eye, I diffed the vocabulary of every
file before and after. Across all 16, **the only words that disappear are the
`param` / `returns` / `raises` markers themselves.** No description was dropped,
truncated or reworded.

## One docstring needed real restructuring

`trials_and_errors_optimization`'s `kwargs` entry documents a nested bullet list
whose continuation lines sat at the bullet indent. That was already awkward as
reST; under `Args:` it parsed as a malformed list. The list is now properly
indented with its own blank line, and its inline literals marked up.

## Verification

- `uv run task lint` — all checks passed
- `uv run task typecheck` — no issues in 133 source files
- `uv run pytest` — 2448 passed, 5 skipped
- Docs build warnings stay at **76**, still **0 from docstrings**
- Converted docstrings render as Parameters tables (31 on the optimization page, 46 symbolic, 20 geometry), with no raw `:param` leaking into the HTML

## Still outstanding

The 76 remaining warnings are unchanged and untouched here — 38 broken README
links (19 unique, doubled because `index.rst` renders the README both as a
toctree page and as an inline `include`) and 38 ambiguous `Dyad` references
(two different classes share the name: `assur.groups.Dyad` and
`synthesis.core.Dyad`). Those are the next steps.