### PR TITLE
docs(readme): make the links resolve outside GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Broken README links, on three surfaces at once.** The README linked to the
+  15 tutorial notebooks, `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` with
+  repository-relative paths. Those resolve only on GitHub: on the PyPI landing
+  page and in the rendered documentation they were dead. They are now absolute
+  GitHub URLs, matching how the README already linked its images. The in-page
+  `[tutorials](#tutorials)` link is fixed by enabling `myst_heading_anchors`,
+  so heading anchors resolve in the docs as they do on GitHub.
+
+- **The README was rendered twice in the documentation.** `index.rst` listed it
+  in the toctree *and* pulled it in again with `.. include::`, so the front page
+  duplicated the entire README and every warning it produced was counted twice.
+  The inline include is removed; the README remains as its own page, linked
+  first under Introduction. Docs build warnings drop from 76 to 38.
+
 - **Docstrings rendered wrongly in the API reference.** The codebase writes
   Google-style docstrings (`Args:`, `Returns:`, `Raises:`), but the docs never
   enabled `sphinx.ext.napoleon`, so every one of them was parsed as a

--- a/README.md
+++ b/README.md
@@ -147,25 +147,25 @@ trajectories = compute_trajectory_numeric(linkage, params, np.linspace(0, 2*np.p
 
 ## Tutorials
 
-The [`docs/notebooks/`](docs/notebooks/) directory contains hands-on tutorials that walk through each major feature:
+The [`docs/notebooks/`](https://github.com/HugoFara/pylinkage/tree/main/docs/notebooks) directory contains hands-on tutorials that walk through each major feature:
 
 | # | Notebook | What you'll learn |
 |---|----------|-------------------|
-| 01 | [Straight-Line Synthesis](docs/notebooks/01_straight_line_synthesis.ipynb) | Design a mechanism that traces a straight line from scratch |
-| 02 | [Optimize a Coupler Curve](docs/notebooks/02_optimize_coupler_curve.ipynb) | Use PSO to shape a four-bar coupler path |
-| 03 | [Tolerance Analysis](docs/notebooks/03_tolerance_analysis.ipynb) | Monte Carlo analysis for manufacturing variation |
-| 04 | [Cam-Follower Timing](docs/notebooks/04_cam_follower_timing.ipynb) | Design cam profiles with motion laws |
-| 05 | [Symbolic Coupler Curve](docs/notebooks/05_symbolic_coupler_curve.ipynb) | Closed-form trajectory expressions with SymPy |
-| 06 | [Function Generation](docs/notebooks/06_function_generation.ipynb) | Match input/output angle relationships ([Freudenstein](https://en.wikipedia.org/wiki/Ferdinand_Freudenstein)) |
-| 07 | [Motion Generation](docs/notebooks/07_motion_generation.ipynb) | Guide a rigid body through specified poses ([Burmester](https://en.wikipedia.org/wiki/Burmester_theory)) |
-| 08 | [Velocity & Acceleration](docs/notebooks/08_velocity_acceleration.ipynb) | Compute joint velocities and accelerations |
-| 09 | [Transmission Angle & DOF](docs/notebooks/09_transmission_angle_and_dof.ipynb) | Evaluate mechanism quality and [mobility](https://en.wikipedia.org/wiki/Degree_of_freedom_(mechanics)) |
-| 10 | [Mechanism Builder](docs/notebooks/10_mechanism_builder.ipynb) | Link-first definition with `MechanismBuilder` |
-| 11 | [Multi-Objective Optimization](docs/notebooks/11_multi_objective_and_scipy_optimization.ipynb) | Pareto-optimal design with NSGA-II and scipy |
-| 12 | [Three Synthesis Problems](docs/notebooks/12_three_synthesis_problems.ipynb) | Side-by-side comparison of path, function, and motion synthesis |
-| 13 | [Population Abstractions](docs/notebooks/13_population_abstractions.ipynb) | Batch simulation, ranking, and filtering of mechanism families |
-| 14 | [Topology Enumeration](docs/notebooks/14_topology_enumeration_and_synthesis.ipynb) | Enumerate and synthesize across all valid topologies |
-| 15 | [Hypergraph Composition](docs/notebooks/15_hypergraph_composition.ipynb) | Compose mechanisms hierarchically from reusable hypergraph components |
+| 01 | [Straight-Line Synthesis](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/01_straight_line_synthesis.ipynb) | Design a mechanism that traces a straight line from scratch |
+| 02 | [Optimize a Coupler Curve](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/02_optimize_coupler_curve.ipynb) | Use PSO to shape a four-bar coupler path |
+| 03 | [Tolerance Analysis](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/03_tolerance_analysis.ipynb) | Monte Carlo analysis for manufacturing variation |
+| 04 | [Cam-Follower Timing](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/04_cam_follower_timing.ipynb) | Design cam profiles with motion laws |
+| 05 | [Symbolic Coupler Curve](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/05_symbolic_coupler_curve.ipynb) | Closed-form trajectory expressions with SymPy |
+| 06 | [Function Generation](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/06_function_generation.ipynb) | Match input/output angle relationships ([Freudenstein](https://en.wikipedia.org/wiki/Ferdinand_Freudenstein)) |
+| 07 | [Motion Generation](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/07_motion_generation.ipynb) | Guide a rigid body through specified poses ([Burmester](https://en.wikipedia.org/wiki/Burmester_theory)) |
+| 08 | [Velocity & Acceleration](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/08_velocity_acceleration.ipynb) | Compute joint velocities and accelerations |
+| 09 | [Transmission Angle & DOF](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/09_transmission_angle_and_dof.ipynb) | Evaluate mechanism quality and [mobility](https://en.wikipedia.org/wiki/Degree_of_freedom_(mechanics)) |
+| 10 | [Mechanism Builder](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/10_mechanism_builder.ipynb) | Link-first definition with `MechanismBuilder` |
+| 11 | [Multi-Objective Optimization](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/11_multi_objective_and_scipy_optimization.ipynb) | Pareto-optimal design with NSGA-II and scipy |
+| 12 | [Three Synthesis Problems](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/12_three_synthesis_problems.ipynb) | Side-by-side comparison of path, function, and motion synthesis |
+| 13 | [Population Abstractions](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/13_population_abstractions.ipynb) | Batch simulation, ranking, and filtering of mechanism families |
+| 14 | [Topology Enumeration](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/14_topology_enumeration_and_synthesis.ipynb) | Enumerate and synthesize across all valid topologies |
+| 15 | [Hypergraph Composition](https://github.com/HugoFara/pylinkage/blob/main/docs/notebooks/15_hypergraph_composition.ipynb) | Compose mechanisms hierarchically from reusable hypergraph components |
 
 ## What Else Can It Do?
 
@@ -216,4 +216,4 @@ Level 4: Applications   → Optimization, Synthesis, Symbolic, Visualization
 
 ## Contributing
 
-Contributions welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) and respect the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+Contributions welcome! Please see [CONTRIBUTING.md](https://github.com/HugoFara/pylinkage/blob/main/CONTRIBUTING.md) and respect the [CODE_OF_CONDUCT.md](https://github.com/HugoFara/pylinkage/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,10 @@ extensions = [
 # Render "Attributes:" as :ivar: fields rather than standalone .. attribute::
 # directives. Without this, a documented attribute collides with the entry
 # autodoc already generates for the same dataclass field.
+# Generate anchors for h1-h3 headings, so in-page README links such as
+# "[tutorials](#tutorials)" resolve here as they do on GitHub.
+myst_heading_anchors = 3
+
 napoleon_use_ivar = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,8 +36,6 @@ Welcome to pylinkage's documentation!
    Get Support <https://github.com/HugoFara/pylinkage/issues>
    Code of Conduct <code_of_conductlink.rst>
 
-.. include:: readmelink.rst
-
 Indices and tables
 ==================
 


### PR DESCRIPTION
Step two of the docs cleanup, after #33. Takes docs build warnings from **76 to 38**.

## The links were dead on two of the three surfaces the README appears on

The README linked the 15 tutorial notebooks, `CONTRIBUTING.md` and
`CODE_OF_CONDUCT.md` with repository-relative paths. Those resolve on GitHub and
nowhere else:

| Surface | Before | After |
|---|---|---|
| GitHub | works | works |
| **PyPI landing page** | **dead** | works |
| **Rendered docs** | **dead** | works |

The PyPI column is the point — that landing page is the subject of #25. They are
now absolute GitHub URLs, consistent with how the README already linked its
images.

## The `#tutorials` anchor was never actually broken

`[tutorials](#tutorials)` points at a heading that does exist (`## Tutorials`,
README line 148). Myst simply was not generating heading anchors. Enabling
`myst_heading_anchors = 3` makes it resolve in the docs as it does on GitHub —
better than rewriting a link that was correct.

## The README was being rendered twice

`index.rst` listed it in the toctree **and** pulled it in again with
`.. include:: readmelink.rst`. So the front page duplicated the entire README,
and every warning it produced was counted twice — which is why 19 broken links
appeared as 38 warnings.

The inline include is removed. The README keeps its own page, still linked first
under Introduction; the front page is now welcome text plus navigation.

Verified this did not silently drop content: `index.html` is 13.7KB and contains
only the nav entry, while `readmelink.html` is 39.9KB with the full README.

## Result

| Category | Before | After |
|---|---:|---:|
| Broken README links (myst) | 38 | **0** |
| Docstring (docutils) | 0 | 0 |
| Ambiguous cross-references | 38 | 38 |
| **Total** | **76** | **38** |

## Verification

- `sphinx-build` succeeds
- `id="tutorials"` anchor generated and `href="#tutorials"` resolves
- All 15 notebook links render as absolute GitHub URLs
- README page renders in full; front page no longer duplicates it

## What remains

The last 38 warnings are all one thing: **two different classes named `Dyad`** —
`pylinkage.assur.groups.Dyad` and `pylinkage.synthesis.core.Dyad`. Sphinx picks
one arbitrarily, so some `Dyad` links currently land on the wrong class. That is
a library naming collision rather than a docs bug, so it wants a deliberate
decision (and fits the #22 / #23 API-surface discussions) rather than a quiet
fix here.