### PR TITLE
fix(dyads): annotate anchors with Component, not the Dyad alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Documentation links that pointed at the wrong class.** `pylinkage.dyads`
+  exports `Dyad` as a plain alias of `Component` (and `ConnectedDyad` of
+  `ConnectedComponent`), and the package annotated its anchors with that alias —
+  `revolute_anchor: Dyad | _AnchorProxy`. Two unrelated classes are also named
+  `Dyad` (`pylinkage.assur.Dyad`, an Assur group, and `pylinkage.synthesis.Dyad`,
+  a Burmester construct), so Sphinx resolved those annotations to one of them and
+  sent readers to a class the code never referred to. The annotations now name
+  `Component` directly. The `Dyad` and `ConnectedDyad` aliases remain exported
+  and unchanged, so no import breaks. Docs build warnings drop from 38 to 8.
+
 - **Broken README links, on three surfaces at once.** The README linked to the
   15 tutorial notebooks, `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` with
   repository-relative paths. Those resolve only on GitHub: on the PyPI landing

--- a/src/pylinkage/dyads/factory.py
+++ b/src/pylinkage/dyads/factory.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ._base import Dyad, _AnchorProxy
+from ._base import Component, _AnchorProxy
 from .pp import PPDyad
 from .rrp import RRPDyad
 from .rrr import RRRDyad
@@ -86,7 +86,7 @@ def _parse_isomer_signature(signature: str) -> tuple[str, str]:
 
 def create_dyad(
     signature: str,
-    anchors: dict[str, Dyad | _AnchorProxy | Component],
+    anchors: dict[str, Component | _AnchorProxy],
     constraints: dict[str, float] | None = None,
     x: float | None = None,
     y: float | None = None,
@@ -162,7 +162,7 @@ def create_dyad(
 
 
 def _create_rrr_dyad(
-    anchors: dict[str, Dyad | _AnchorProxy | Component],
+    anchors: dict[str, Component | _AnchorProxy],
     constraints: dict[str, float],
     x: float | None,
     y: float | None,
@@ -195,7 +195,7 @@ def _create_rrr_dyad(
 
 
 def _create_rrp_dyad(
-    anchors: dict[str, Dyad | _AnchorProxy | Component],
+    anchors: dict[str, Component | _AnchorProxy],
     constraints: dict[str, float],
     x: float | None,
     y: float | None,
@@ -228,7 +228,7 @@ def _create_rrp_dyad(
 
 
 def _create_pp_dyad(
-    anchors: dict[str, Dyad | _AnchorProxy | Component],
+    anchors: dict[str, Component | _AnchorProxy],
     constraints: dict[str, float],
     x: float | None,
     y: float | None,

--- a/src/pylinkage/dyads/fixed.py
+++ b/src/pylinkage/dyads/fixed.py
@@ -7,7 +7,7 @@ is deterministic (no ambiguity).
 
 from __future__ import annotations
 
-from ._base import BinaryDyad, Dyad, _AnchorProxy
+from ._base import BinaryDyad, Component, _AnchorProxy
 
 
 class FixedDyad(BinaryDyad):
@@ -46,8 +46,8 @@ class FixedDyad(BinaryDyad):
 
     def __init__(
         self,
-        anchor1: Dyad | _AnchorProxy,
-        anchor2: Dyad | _AnchorProxy,
+        anchor1: Component | _AnchorProxy,
+        anchor2: Component | _AnchorProxy,
         distance: float,
         angle: float,
         name: str | None = None,

--- a/src/pylinkage/dyads/pp.py
+++ b/src/pylinkage/dyads/pp.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import math
 
 from .. import exceptions as pl_exceptions
-from ._base import ConnectedDyad, Dyad, _AnchorProxy
+from ._base import Component, ConnectedComponent, _AnchorProxy
 
 
-class PPDyad(ConnectedDyad):
+class PPDyad(ConnectedComponent):
     """PP Dyad - line-line intersection.
 
     Positions a joint at the intersection of two lines:
@@ -45,17 +45,17 @@ class PPDyad(ConnectedDyad):
 
     __slots__ = ("line1_anchor1", "line1_anchor2", "line2_anchor1", "line2_anchor2")
 
-    line1_anchor1: Dyad | _AnchorProxy
-    line1_anchor2: Dyad | _AnchorProxy
-    line2_anchor1: Dyad | _AnchorProxy
-    line2_anchor2: Dyad | _AnchorProxy
+    line1_anchor1: Component | _AnchorProxy
+    line1_anchor2: Component | _AnchorProxy
+    line2_anchor1: Component | _AnchorProxy
+    line2_anchor2: Component | _AnchorProxy
 
     def __init__(
         self,
-        line1_anchor1: Dyad | _AnchorProxy,
-        line1_anchor2: Dyad | _AnchorProxy,
-        line2_anchor1: Dyad | _AnchorProxy,
-        line2_anchor2: Dyad | _AnchorProxy,
+        line1_anchor1: Component | _AnchorProxy,
+        line1_anchor2: Component | _AnchorProxy,
+        line2_anchor1: Component | _AnchorProxy,
+        line2_anchor2: Component | _AnchorProxy,
         x: float | None = None,
         y: float | None = None,
         name: str | None = None,
@@ -82,7 +82,7 @@ class PPDyad(ConnectedDyad):
             self._initialize_position()
 
     @property
-    def anchors(self) -> tuple[Dyad, Dyad, Dyad, Dyad]:
+    def anchors(self) -> tuple[Component, Component, Component, Component]:
         """Return the parent dyads (four line anchors)."""
         return (
             self._resolve_anchor(self.line1_anchor1),
@@ -91,14 +91,14 @@ class PPDyad(ConnectedDyad):
             self._resolve_anchor(self.line2_anchor2),
         )
 
-    def _resolve_anchor(self, anchor: Dyad | _AnchorProxy) -> Dyad:
-        """Resolve an anchor reference to its Dyad."""
+    def _resolve_anchor(self, anchor: Component | _AnchorProxy) -> Component:
+        """Resolve an anchor reference to its Component."""
         if isinstance(anchor, _AnchorProxy):
             return anchor._parent
         return anchor
 
     def _get_anchor_position(
-        self, anchor: Dyad | _AnchorProxy
+        self, anchor: Component | _AnchorProxy
     ) -> tuple[float | None, float | None]:
         """Get the position of an anchor."""
         if isinstance(anchor, _AnchorProxy):

--- a/src/pylinkage/dyads/rrp.py
+++ b/src/pylinkage/dyads/rrp.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import math
 
 from .. import exceptions as pl_exceptions
-from ._base import ConnectedDyad, Dyad, _AnchorProxy
+from ._base import Component, ConnectedComponent, _AnchorProxy
 
 
-class RRPDyad(ConnectedDyad):
+class RRPDyad(ConnectedComponent):
     """RRP Dyad - circle-line intersection (slider mechanism).
 
     Positions a joint at the intersection of:
@@ -47,16 +47,16 @@ class RRPDyad(ConnectedDyad):
 
     __slots__ = ("revolute_anchor", "line_anchor1", "line_anchor2", "distance")
 
-    revolute_anchor: Dyad | _AnchorProxy
-    line_anchor1: Dyad | _AnchorProxy
-    line_anchor2: Dyad | _AnchorProxy
+    revolute_anchor: Component | _AnchorProxy
+    line_anchor1: Component | _AnchorProxy
+    line_anchor2: Component | _AnchorProxy
     distance: float
 
     def __init__(
         self,
-        revolute_anchor: Dyad | _AnchorProxy,
-        line_anchor1: Dyad | _AnchorProxy,
-        line_anchor2: Dyad | _AnchorProxy,
+        revolute_anchor: Component | _AnchorProxy,
+        line_anchor1: Component | _AnchorProxy,
+        line_anchor2: Component | _AnchorProxy,
         distance: float,
         x: float | None = None,
         y: float | None = None,
@@ -84,7 +84,7 @@ class RRPDyad(ConnectedDyad):
             self._initialize_position()
 
     @property
-    def anchors(self) -> tuple[Dyad, Dyad, Dyad]:
+    def anchors(self) -> tuple[Component, Component, Component]:
         """Return the parent dyads (revolute anchor, line anchors)."""
         ra = (
             self.revolute_anchor._parent
@@ -104,7 +104,7 @@ class RRPDyad(ConnectedDyad):
         return (ra, la1, la2)
 
     def _get_anchor_position(
-        self, anchor: Dyad | _AnchorProxy
+        self, anchor: Component | _AnchorProxy
     ) -> tuple[float | None, float | None]:
         """Get the position of an anchor."""
         if isinstance(anchor, _AnchorProxy):

--- a/src/pylinkage/dyads/rrr.py
+++ b/src/pylinkage/dyads/rrr.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import math
 
 from .. import exceptions as pl_exceptions
-from ._base import BinaryDyad, Dyad, _AnchorProxy
+from ._base import BinaryDyad, Component, _AnchorProxy
 
 
 class RRRDyad(BinaryDyad):
@@ -47,8 +47,8 @@ class RRRDyad(BinaryDyad):
 
     def __init__(
         self,
-        anchor1: Dyad | _AnchorProxy,
-        anchor2: Dyad | _AnchorProxy,
+        anchor1: Component | _AnchorProxy,
+        anchor2: Component | _AnchorProxy,
         distance1: float,
         distance2: float,
         x: float | None = None,


### PR DESCRIPTION
Takes docs build warnings from **38 to 8**, without touching the public API.

## There are three `Dyad`s, and the third caused the problem

| Name | What it actually is |
|---|---|
| `pylinkage.assur.Dyad` | Assur group: 2 links, 3 joints, 1 internal node |
| `pylinkage.synthesis.Dyad` | Burmester dyad: a circle-point / center-point pair |
| `pylinkage.dyads.Dyad` | **a plain alias of `Component`** (`components/_base.py:218`) |

The third is not a dyad at all. `Dyad = Component` and
`ConnectedDyad = ConnectedComponent` are compatibility aliases — and the `dyads`
package used them in its own annotations, so signatures read
`revolute_anchor: Dyad | _AnchorProxy` (`rrp.py:50`) while meaning `Component`.

Sphinx resolved that annotation to one of the two *real* `Dyad` classes. **The
rendered links were not ambiguous, they were wrong** — readers clicking the
anchor type of an `RRPDyad` landed on an Assur group or a Burmester construct.

## The fix

Annotations and base classes inside `dyads/` now name `Component` and
`ConnectedComponent` directly.

**Nothing about the public API changes.** The aliases stay exported from both
`pylinkage.dyads` and `pylinkage.components`; verified after the change:

```
dyads.Dyad is Component      : True
dyads.ConnectedDyad is CC    : True
Dyad in dyads.__all__        : True
RRPDyad base                 : ConnectedComponent   (same object, real name)
PPDyad base                  : ConnectedComponent
```

## Result

| | Before | After |
|---|---:|---:|
| Ambiguous `Dyad` references | 38 | **8** |

Better than the 24 I expected — most of the warnings reported against
`<unknown>` traced back to these alias annotations too, not just the 14 attributed
to `pylinkage.dyads.rst`.

## Verification

- `uv run task lint` — all checks passed
- `uv run task typecheck` — no issues in 133 source files
- `uv run pytest` — 2448 passed, 5 skipped
- Aliases confirmed identical and still exported (above)

## What remains, deliberately

The last 8 warnings are the genuine collision between `assur.Dyad` and
`synthesis.Dyad`. Resolving it means renaming a public class — my suggestion is
`synthesis.Dyad` → `BurmesterDyad`, since `assur.Dyad` sits in a family
(`Triad`, `DyadRRR`, `DyadRRP`, `DyadPRR`) where the bare name reads naturally,
and to deprecate the misleading `dyads.Dyad` / `ConnectedDyad` aliases at the
same time.

That is a breaking change and belongs in a minor release under the deprecation
policy #22 is meant to establish — not in a patch. External exposure is low
(bare `Dyad` appears zero times in the README and notebooks), so there is no
urgency to force it early.