### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-09-04
+
 ### Added
 
 - **Public benchmarks.** `docs/source/benchmarks.md` reports figures for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   needed, since `[tool.hatch.build.targets.wheel]` already covers the whole
   package directory.
 
+- **The front-page example did not say what to install.** The first snippet in
+  the README — the one PyPI shows above the fold, and the one reported in #25 —
+  calls `path_generation()` and `show_linkage()`, which live behind the `scipy`
+  and `viz` extras. Every other example needing an extra said so; this one did
+  not, so after a plain `pip install pylinkage` it raised `ModuleNotFoundError`
+  before reaching any pylinkage code. It now names the install line it needs.
+
 - **Broken examples on the PyPI landing page.** Both README visualization
   snippets called `plot_kinematic_linkage(linkage)`, but that function takes
   `(linkage, fig, axis, loci)` and always has — the signature is identical in

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: Hugo
     orcid: "https://orcid.org/0009-0001-0769-4434"
     affiliation: "Independent Researcher, France"
-version: 1.1.0
-date-released: "2026-08-12"
+version: 1.1.1
+date-released: "2026-09-04"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21207487"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ result = path_generation([(0, 0), (1, 1), (2, 1), (3, 0)])
 show_linkage(result.solutions[0])
 ```
 
+To run that example: `pip install pylinkage[scipy,viz]`. Synthesis needs SciPy and
+plotting needs Matplotlib; both are [optional extras](#installation), so a plain
+`pip install pylinkage` gives you the core library without them.
+
 ![Path generation result](https://github.com/HugoFara/pylinkage/raw/main/docs/assets/synthesis_path_generation.gif)
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pylinkage"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     {name = "Hugo Farajallah", email = "contact@hugofara.net"},
 ]
@@ -157,7 +157,7 @@ typecheck = "mypy src/pylinkage"
 api = "python -m uvicorn api.main:app --reload --port 8000"
 
 [tool.bumpversion]
-current_version = "1.1.0"
+current_version = "1.1.1"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/src/pylinkage/__init__.py
+++ b/src/pylinkage/__init__.py
@@ -187,4 +187,4 @@ def __getattr__(name: str) -> object:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -3134,7 +3134,7 @@ wheels = [
 
 [[package]]
 name = "pylinkage"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Cuts 1.1.1, the release that closes #25.

## Version bump

`pyproject.toml`, `src/pylinkage/__init__.py`, `CITATION.cff`, `uv.lock`, and the `CHANGELOG.md` heading — the same five files as the 1.1.0 bump.

## One extra fix, found while verifying the release

The point of 1.1.1 is that the PyPI front-page example works. It still didn't, for a second reason.

Installing the built wheel into a clean venv and running the README's first snippet — the one #25 quotes — gives:

```
ModuleNotFoundError: No module named 'scipy'
```

`path_generation()` needs the `scipy` extra and `show_linkage()` needs `viz`. Neither is a default dependency, and unlike every other example in the README, this one didn't say so. So the reporter's exact snippet would still have failed on 1.1.1, with a different traceback, and #25 would have come straight back. The snippet now names `pip install pylinkage[scipy,viz]`.

## Verification

All five README code blocks were run against the built 1.1.1 wheel in a clean venv, headless:

| Block | Result |
|---|---|
| `path_generation` + `show_linkage` | 10 solutions, plots |
| Component four-bar | builds, plots |
| `MechanismBuilder` | steps |
| PSO | converges, best score -5.00 |
| Symbolic | returns trajectories |

Also checked:

- `twine check` passes on both sdist and wheel
- `py.typed` is present in the wheel
- `pylinkage.__version__` reports `1.1.1` from the installed wheel
- lint, `mypy --strict` (133 files), and 2448 tests pass

## Note on the version number

Strictly, `[Unreleased]` has an **Added** section — `pylinkage.dyads.to_mechanism()` became public — which semver would make a minor. Everything else is docs, packaging, and fixes. Cutting it as 1.1.1 as requested; flagging it since the number is the one thing that can't be changed after publishing.

## Still open on #25

The reporter's second question, about Jupyter plotting backends (`%matplotlib inline` / `widget`), is not addressed here. That wants an answer on the issue and probably a README note, but it is not a blocker for the release.

After merge, the remaining step is tagging `v1.1.1` on main and publishing the GitHub release, which triggers the PyPI upload.