### PR TITLE
Deprecate the Dyad aliases, rename synthesis.Dyad to BurmesterDyad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`pylinkage.synthesis.BurmesterDyad`**, the new name for what was
+  `pylinkage.synthesis.Dyad`. Same class, same behaviour; the old name still
+  works and now warns.
+
+- **A deprecation policy, at `docs/source/deprecations.md`.** One page stating
+  what pylinkage promises about public names: a name is announced with a
+  `DeprecationWarning` naming its replacement and removal release, and is
+  removed no earlier than the next major version. It carries the table of
+  everything currently deprecated, and how to surface the warnings, which are
+  silent by default in Python.
+
+- `pylinkage._deprecation`, the machinery behind that: deprecated names are
+  removed from their module's namespace and served by a module-level
+  `__getattr__` (PEP 562), so reading one warns while `from ... import Name`
+  keeps resolving exactly as before.
+
+### Deprecated
+
+- **The three `Dyad` names that were not what they said.** Three unrelated
+  classes were reachable as `Dyad`, and only two were dyads at all:
+  `pylinkage.assur.Dyad` (an Assur group, unaffected and keeping its name),
+  `pylinkage.synthesis.Dyad` (a Burmester dyad, now `BurmesterDyad`), and
+  `pylinkage.components.Dyad` / `pylinkage.dyads.Dyad` with their
+  `ConnectedDyad` counterparts, which were plain aliases of `Component` and
+  `ConnectedComponent` — a `Ground` point is a `Component`, and calling it a
+  dyad is simply wrong. All four aliases now emit a `DeprecationWarning` and
+  are scheduled for removal in 2.0.0. Nothing breaks: each name still resolves
+  to the same object it always did, and stays in its module's `__all__`.
+
+  The concrete cost of the collision was that Sphinx could not tell the three
+  apart, so cross-references landed on the wrong class. With the aliases
+  deprecated and the rename in place, the documentation build goes from 8
+  warnings to **0**.
+
 ## [1.1.1] - 2026-09-04
 
 ### Added

--- a/docs/source/deprecations.md
+++ b/docs/source/deprecations.md
@@ -1,0 +1,80 @@
+# Deprecations
+
+Names that still work but are on their way out, with what to use instead.
+
+## How deprecation works here
+
+pylinkage follows [semantic versioning](https://semver.org/spec/v2.0.0.html).
+A public name is never removed without notice:
+
+1. **Announced.** The name keeps working and keeps resolving to the same
+   object, but reading it raises a `DeprecationWarning` naming the replacement
+   and the release that will drop it.
+2. **Removed.** No earlier than the next *major* release.
+
+`DeprecationWarning` is silent by default in Python, so nothing in your output
+changes until you go looking. To see them:
+
+```bash
+python -W error::DeprecationWarning your_script.py   # fail on any use
+python -W default::DeprecationWarning your_script.py # just print them
+```
+
+Under pytest, `filterwarnings = ["error::DeprecationWarning"]` in your config
+turns each one into a test failure, which is the cheapest way to find out
+whether an upgrade will affect you.
+
+## Currently deprecated
+
+| Name | Use instead | Removed in |
+|---|---|---|
+| `pylinkage.components.Dyad` | `pylinkage.components.Component` | 2.0.0 |
+| `pylinkage.components.ConnectedDyad` | `pylinkage.components.ConnectedComponent` | 2.0.0 |
+| `pylinkage.dyads.Dyad` | `pylinkage.components.Component` | 2.0.0 |
+| `pylinkage.dyads.ConnectedDyad` | `pylinkage.components.ConnectedComponent` | 2.0.0 |
+| `pylinkage.synthesis.Dyad` | `pylinkage.synthesis.BurmesterDyad` | 2.0.0 |
+
+### Why the `Dyad` names are going away
+
+Three unrelated classes were reachable as `Dyad`, and only two of them were
+dyads at all:
+
+- `pylinkage.assur.Dyad` — an Assur group. A genuine dyad, and **unaffected**;
+  it keeps its name.
+- `pylinkage.synthesis.Dyad` — a Burmester dyad: a circle point paired with a
+  center point. Also a genuine dyad, but a specific kind, now named
+  `BurmesterDyad`.
+- `pylinkage.components.Dyad` and `pylinkage.dyads.Dyad` — plain aliases of
+  `Component`. Never dyads. A `Ground` point is a `Component`, and calling it a
+  dyad is simply wrong.
+
+The practical cost was that documentation cross-references could not tell the
+three apart, so a link on one class would take you to another. Since
+`pylinkage.dyads` annotated its anchor parameters with the alias, the anchor
+type on every `RRRDyad`, `RRPDyad`, `PPDyad` and `FixedDyad` pointed at a class
+the code never referred to.
+
+### Migrating
+
+Renaming the import is the whole change — the objects are unchanged, and the
+aliases still point at exactly what they always did:
+
+```python
+# Before
+from pylinkage.dyads import Dyad, ConnectedDyad
+from pylinkage.synthesis import Dyad
+
+# After
+from pylinkage.components import Component, ConnectedComponent
+from pylinkage.synthesis import BurmesterDyad
+```
+
+`isinstance` checks keep working through the transition, because the deprecated
+name and its replacement are the same object:
+
+```python
+>>> from pylinkage.components import Component
+>>> import pylinkage.dyads
+>>> pylinkage.dyads.Dyad is Component   # emits DeprecationWarning
+True
+```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to pylinkage's documentation!
    Readme <readmelink>
    changeloglink
    benchmarks
+   deprecations
 
 .. toctree::
    :maxdepth: 2

--- a/src/pylinkage/_deprecation.py
+++ b/src/pylinkage/_deprecation.py
@@ -1,0 +1,82 @@
+"""Machinery for deprecating a public name without breaking imports.
+
+A deprecated name is removed from its module's namespace and served by a
+module-level ``__getattr__`` (PEP 562) instead. Reading it still works —
+``from pylinkage.dyads import Dyad`` resolves as it always did — but now
+emits a :class:`DeprecationWarning` naming the replacement and the release
+that will drop it.
+
+Deprecations follow the policy in :doc:`/deprecations`: a name is announced
+in one release and removed no earlier than the next major one.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = ["DeprecatedAlias", "deprecated_getattr"]
+
+
+@dataclass(frozen=True)
+class DeprecatedAlias:
+    """A public name kept alive only for backwards compatibility.
+
+    Attributes:
+        value: Object the deprecated name resolves to.
+        replacement: Fully qualified name callers should use instead.
+        removed_in: pylinkage version that will stop providing the name.
+        reason: Why the name is going away. Appended to the warning.
+    """
+
+    value: Any
+    replacement: str
+    removed_in: str
+    reason: str = ""
+
+    def message(self, module: str, name: str) -> str:
+        """Build the warning text shown for ``module.name``.
+
+        Args:
+            module: Module the deprecated name is read from.
+            name: The deprecated name itself.
+
+        Returns:
+            A sentence naming the replacement and the removal release,
+            followed by the reason when one is given.
+        """
+        text = (
+            f"{module}.{name} is deprecated and will be removed in "
+            f"pylinkage {self.removed_in}; use {self.replacement} instead."
+        )
+        return f"{text} {self.reason}" if self.reason else text
+
+
+def deprecated_getattr(
+    module: str,
+    aliases: Mapping[str, DeprecatedAlias],
+) -> Callable[[str], Any]:
+    """Build a module-level ``__getattr__`` that serves deprecated aliases.
+
+    Bind the result as ``__getattr__`` at module scope. Names absent from
+    ``aliases`` raise :class:`AttributeError` as usual, so the hook stays
+    invisible to everything else.
+
+    Args:
+        module: ``__name__`` of the module installing the hook.
+        aliases: Deprecated name mapped to the alias describing it.
+
+    Returns:
+        A function suitable for binding as the module's ``__getattr__``.
+    """
+
+    def __getattr__(name: str) -> Any:
+        alias = aliases.get(name)
+        if alias is None:
+            raise AttributeError(f"module {module!r} has no attribute {name!r}")
+        warnings.warn(alias.message(module, name), DeprecationWarning, stacklevel=2)
+        return alias.value
+
+    return __getattr__

--- a/src/pylinkage/components/__init__.py
+++ b/src/pylinkage/components/__init__.py
@@ -9,19 +9,16 @@ Classes:
     PointTracker: Sensor for tracking positions on links
     _AnchorProxy: Proxy for output position access (internal)
 
-The Component class (and its alias Dyad) serves as the base for all
-user-facing kinematic building blocks including:
+The Component class serves as the base for all user-facing kinematic
+building blocks including:
 - Ground points (this module)
 - Actuators (see pylinkage.actuators)
 - Assur dyads (see pylinkage.dyads)
 """
 
+from .._deprecation import DeprecatedAlias, deprecated_getattr
 from ._base import Component as Component
 from ._base import ConnectedComponent as ConnectedComponent
-
-# Backwards compatibility aliases
-from ._base import ConnectedDyad as ConnectedDyad
-from ._base import Dyad as Dyad
 from ._base import _AnchorProxy as _AnchorProxy
 from .ground import Ground as Ground
 from .point_tracker import PointTracker as PointTracker
@@ -32,7 +29,34 @@ __all__ = [
     "Ground",
     "PointTracker",
     "_AnchorProxy",
-    # Backwards compatibility
+    # Deprecated aliases, served by __getattr__ below.
     "Dyad",
     "ConnectedDyad",
 ]
+
+
+# ``Dyad`` and ``ConnectedDyad`` never denoted dyads: they are plain aliases of
+# ``Component`` and ``ConnectedComponent``, and the name collides with two real
+# dyad classes elsewhere in the package.
+_ALIAS_REASON = (
+    "These are plain aliases of the component base classes rather than dyads, "
+    "and the name collides with pylinkage.assur.Dyad and "
+    "pylinkage.synthesis.BurmesterDyad, which are genuine dyads."
+)
+
+_DEPRECATED = {
+    "Dyad": DeprecatedAlias(
+        value=Component,
+        replacement="pylinkage.components.Component",
+        removed_in="2.0.0",
+        reason=_ALIAS_REASON,
+    ),
+    "ConnectedDyad": DeprecatedAlias(
+        value=ConnectedComponent,
+        replacement="pylinkage.components.ConnectedComponent",
+        removed_in="2.0.0",
+        reason=_ALIAS_REASON,
+    ),
+}
+
+__getattr__ = deprecated_getattr(__name__, _DEPRECATED)

--- a/src/pylinkage/components/_base.py
+++ b/src/pylinkage/components/_base.py
@@ -212,8 +212,3 @@ class _AnchorProxy:
     def acceleration(self) -> tuple[float, float] | None:
         """Return the parent's acceleration."""
         return self._parent.acceleration
-
-
-# Backwards compatibility aliases
-Dyad = Component
-ConnectedDyad = ConnectedComponent

--- a/src/pylinkage/dyads/__init__.py
+++ b/src/pylinkage/dyads/__init__.py
@@ -53,21 +53,18 @@ Backwards Compatibility:
     - Ground: from pylinkage.components
     - Crank, LinearActuator: from pylinkage.actuators
     - Linkage: from pylinkage.simulation
-    - Dyad, ConnectedDyad: aliases for Component, ConnectedComponent
+    - Dyad, ConnectedDyad: deprecated aliases, see the Deprecations page
 """
 
-# Primary exports - true Assur groups
-# Actuators
+# Primary exports are the true Assur groups defined in this package; the rest
+# are re-exports kept for backwards compatibility.
+from .._deprecation import DeprecatedAlias, deprecated_getattr
 from ..actuators import ArcCrank as ArcCrank
 from ..actuators import Crank as Crank
 from ..actuators import LinearActuator as LinearActuator
-
-# Re-exports for backwards compatibility
-# Base classes (with proper aliases)
+from ..components import _ALIAS_REASON
 from ..components import Component as Component
 from ..components import ConnectedComponent as ConnectedComponent
-from ..components import ConnectedDyad as ConnectedDyad  # Alias for ConnectedComponent
-from ..components import Dyad as Dyad  # Alias for Component
 
 # Ground and sensors from components
 from ..components import Ground as Ground
@@ -116,7 +113,26 @@ __all__ = [
     # Base classes
     "Component",
     "ConnectedComponent",
-    "Dyad",  # Alias for Component
-    "ConnectedDyad",  # Alias for ConnectedComponent
     "_AnchorProxy",
+    # Deprecated aliases, served by __getattr__ below.
+    "Dyad",
+    "ConnectedDyad",
 ]
+
+
+_DEPRECATED = {
+    "Dyad": DeprecatedAlias(
+        value=Component,
+        replacement="pylinkage.components.Component",
+        removed_in="2.0.0",
+        reason=_ALIAS_REASON,
+    ),
+    "ConnectedDyad": DeprecatedAlias(
+        value=ConnectedComponent,
+        replacement="pylinkage.components.ConnectedComponent",
+        removed_in="2.0.0",
+        reason=_ALIAS_REASON,
+    ),
+}
+
+__getattr__ = deprecated_getattr(__name__, _DEPRECATED)

--- a/src/pylinkage/dyads/_base.py
+++ b/src/pylinkage/dyads/_base.py
@@ -8,12 +8,8 @@ from __future__ import annotations
 
 from ..components import Component, ConnectedComponent, _AnchorProxy
 
-# Re-export for backwards compatibility and use by dyad classes
-__all__ = ["BinaryDyad", "Dyad", "ConnectedDyad", "_AnchorProxy", "Component", "ConnectedComponent"]
-
-# Backwards compatibility aliases
-Dyad = Component
-ConnectedDyad = ConnectedComponent
+# Re-exported for use by the dyad classes in this package
+__all__ = ["BinaryDyad", "_AnchorProxy", "Component", "ConnectedComponent"]
 
 
 class BinaryDyad(ConnectedComponent):

--- a/src/pylinkage/synthesis/__init__.py
+++ b/src/pylinkage/synthesis/__init__.py
@@ -135,8 +135,10 @@ __all__ = [
     # Core classes
     "SynthesisProblem",
     "SynthesisResult",
-    "Dyad",
+    "BurmesterDyad",
     "BurmesterCurves",
+    # Deprecated alias, served by __getattr__ below.
+    "Dyad",
     # Main synthesis functions
     "function_generation",
     "verify_function_generation",
@@ -178,6 +180,7 @@ __all__ = [
 ]
 
 # Type definitions
+from .._deprecation import DeprecatedAlias, deprecated_getattr
 from ._types import (
     AnglePair,
     ComplexPoint,
@@ -213,7 +216,7 @@ from .conversion import (
 # Core classes
 from .core import (
     BurmesterCurves,
-    Dyad,
+    BurmesterDyad,
     SynthesisProblem,
     SynthesisResult,
 )
@@ -243,3 +246,18 @@ from .utils import (
     is_grashof,
     validate_fourbar,
 )
+
+_DEPRECATED = {
+    "Dyad": DeprecatedAlias(
+        value=BurmesterDyad,
+        replacement="pylinkage.synthesis.BurmesterDyad",
+        removed_in="2.0.0",
+        reason=(
+            "The class is a Burmester dyad specifically, and the bare name "
+            "collided with pylinkage.assur.Dyad, an Assur group, so "
+            "documentation cross-references resolved to the wrong class."
+        ),
+    ),
+}
+
+__getattr__ = deprecated_getattr(__name__, _DEPRECATED)

--- a/src/pylinkage/synthesis/burmester.py
+++ b/src/pylinkage/synthesis/burmester.py
@@ -36,7 +36,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ._types import ComplexPoint, Point2D, Pose
-from .core import BurmesterCurves, Dyad
+from .core import BurmesterCurves, BurmesterDyad
 
 if TYPE_CHECKING:
     pass
@@ -510,7 +510,7 @@ def select_compatible_dyads(
     ground_constraint: tuple[Point2D, Point2D] | None = None,
     ground_tolerance: float = 0.1,
     max_pairs: int | None = None,
-) -> list[tuple[Dyad, Dyad]]:
+) -> list[tuple[BurmesterDyad, BurmesterDyad]]:
     """Select pairs of dyads that form valid four-bar linkages.
 
     Two dyads form a valid four-bar if:
@@ -530,7 +530,7 @@ def select_compatible_dyads(
     Returns:
         List of (dyad_left, dyad_right) pairs forming valid 4-bars.
     """
-    dyad_pairs: list[tuple[Dyad, Dyad]] = []
+    dyad_pairs: list[tuple[BurmesterDyad, BurmesterDyad]] = []
 
     n = len(curves)
     if n < 2:

--- a/src/pylinkage/synthesis/core.py
+++ b/src/pylinkage/synthesis/core.py
@@ -3,7 +3,7 @@
 This module provides the fundamental data structures for mechanism synthesis:
 - SynthesisProblem: Definition of a synthesis problem
 - SynthesisResult: Container for synthesis solutions
-- Dyad: A kinematic dyad from Burmester theory
+- BurmesterDyad: A kinematic dyad from Burmester theory
 - BurmesterCurves: Circle point and center point curves
 """
 
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
+from .._deprecation import DeprecatedAlias, deprecated_getattr
 from ._types import (
     AnglePair,
     ComplexPoint,
@@ -178,7 +179,7 @@ class SynthesisResult:
 
 
 @dataclass(frozen=True, slots=True)
-class Dyad:
+class BurmesterDyad:
     """A kinematic dyad (two-link chain) from Burmester theory.
 
     In Burmester theory, a dyad connects a moving point on the coupler
@@ -256,25 +257,25 @@ class BurmesterCurves:
         """True if curves contain any points."""
         return len(self.circle_curve) > 0
 
-    def get_dyad(self, index: int) -> Dyad:
+    def get_dyad(self, index: int) -> BurmesterDyad:
         """Get dyad at specific parameter index.
 
         Args:
             index: Index into the curve arrays.
 
         Returns:
-            Dyad at the specified index.
+            BurmesterDyad at the specified index.
         """
-        return Dyad(
+        return BurmesterDyad(
             circle_point=self.circle_curve[index],
             center_point=self.center_curve[index],
         )
 
-    def get_all_dyads(self) -> list[Dyad]:
+    def get_all_dyads(self) -> list[BurmesterDyad]:
         """Get all dyads from the curves.
 
         Returns:
-            List of Dyad objects, one per curve point.
+            List of BurmesterDyad objects, one per curve point.
         """
         return [self.get_dyad(i) for i in range(len(self))]
 
@@ -313,3 +314,19 @@ class BurmesterCurves:
             parameter=self.parameter[finite_mask],
             is_discrete=self.is_discrete,
         )
+
+
+_DEPRECATED = {
+    "Dyad": DeprecatedAlias(
+        value=BurmesterDyad,
+        replacement="pylinkage.synthesis.BurmesterDyad",
+        removed_in="2.0.0",
+        reason=(
+            "The class is a Burmester dyad specifically, and the bare name "
+            "collided with pylinkage.assur.Dyad, an Assur group, so "
+            "documentation cross-references resolved to the wrong class."
+        ),
+    ),
+}
+
+__getattr__ = deprecated_getattr(__name__, _DEPRECATED)

--- a/src/pylinkage/synthesis/motion_generation.py
+++ b/src/pylinkage/synthesis/motion_generation.py
@@ -36,7 +36,7 @@ from .burmester import (
     compute_circle_point_curve,
     select_compatible_dyads,
 )
-from .core import Dyad, SynthesisProblem, SynthesisResult
+from .core import BurmesterDyad, SynthesisProblem, SynthesisResult
 from .utils import GrashofType, grashof_check, validate_fourbar
 
 if TYPE_CHECKING:
@@ -44,8 +44,8 @@ if TYPE_CHECKING:
 
 
 def _dyads_to_motion_fourbar(
-    dyad_left: Dyad,
-    dyad_right: Dyad,
+    dyad_left: BurmesterDyad,
+    dyad_right: BurmesterDyad,
     reference_pose: Pose,
 ) -> FourBarSolution | None:
     """Convert dyads to four-bar for motion generation.
@@ -54,8 +54,8 @@ def _dyads_to_motion_fourbar(
     (coupler) and the center points are fixed pivots (frame).
 
     Args:
-        dyad_left: Dyad for left side (A-B connection).
-        dyad_right: Dyad for right side (D-C connection).
+        dyad_left: BurmesterDyad for left side (A-B connection).
+        dyad_right: BurmesterDyad for right side (D-C connection).
         reference_pose: Reference pose (typically first pose).
 
     Returns:

--- a/src/pylinkage/synthesis/path_generation.py
+++ b/src/pylinkage/synthesis/path_generation.py
@@ -42,7 +42,7 @@ from .burmester import (
     compute_circle_point_curve,
     select_compatible_dyads,
 )
-from .core import Dyad, SynthesisProblem, SynthesisResult
+from .core import BurmesterDyad, SynthesisProblem, SynthesisResult
 from .utils import GrashofType, grashof_check, validate_fourbar
 
 if TYPE_CHECKING:
@@ -167,8 +167,8 @@ def _points_to_poses(
 
 
 def _dyads_to_fourbar(
-    dyad_left: Dyad,
-    dyad_right: Dyad,
+    dyad_left: BurmesterDyad,
+    dyad_right: BurmesterDyad,
     coupler_point_world: Point2D | None = None,
 ) -> FourBarSolution | None:
     """Convert two dyads to a four-bar solution.
@@ -177,8 +177,8 @@ def _dyads_to_fourbar(
     The right dyad connects ground pivot D to coupler point C.
 
     Args:
-        dyad_left: Dyad for the crank side (A-B).
-        dyad_right: Dyad for the rocker side (D-C).
+        dyad_left: BurmesterDyad for the crank side (A-B).
+        dyad_right: BurmesterDyad for the rocker side (D-C).
         coupler_point_world: World-frame position of the traced coupler
             point at the first precision position. This is the point that
             should pass through the precision points.

--- a/src/pylinkage/synthesis/topology_types.py
+++ b/src/pylinkage/synthesis/topology_types.py
@@ -15,7 +15,7 @@ from ._types import Point2D
 if TYPE_CHECKING:
     from ..simulation import Linkage
     from ..topology.catalog import CatalogEntry
-    from .core import Dyad
+    from .core import BurmesterDyad
 
 # A partition of precision point indices across Assur groups.
 # E.g., ((0, 1, 2), (3, 4)) assigns points 0-2 to group 0 and 3-4 to group 1.
@@ -37,7 +37,7 @@ class GroupSynthesisResult:
 
     group_index: int
     group_signature: str
-    dyads: tuple[Dyad, Dyad] | None = None
+    dyads: tuple[BurmesterDyad, BurmesterDyad] | None = None
     joint_positions: dict[str, Point2D] = field(default_factory=dict)
     precision_indices: tuple[int, ...] = ()
     residual: float = 0.0

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,92 @@
+"""Deprecated public names still resolve, and say so.
+
+Each name here is deprecated and scheduled for removal in 2.0.0. The point of
+these tests is that the compatibility promise holds -- the name keeps working,
+and keeps pointing at the same object -- while reading it warns.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import pylinkage.components
+import pylinkage.dyads
+import pylinkage.synthesis
+from pylinkage.assur import Dyad as AssurDyad
+from pylinkage.components import Component, ConnectedComponent
+from pylinkage.synthesis import BurmesterDyad
+
+# (module, deprecated name, object it must resolve to)
+ALIASES = [
+    (pylinkage.components, "Dyad", Component),
+    (pylinkage.components, "ConnectedDyad", ConnectedComponent),
+    (pylinkage.dyads, "Dyad", Component),
+    (pylinkage.dyads, "ConnectedDyad", ConnectedComponent),
+    (pylinkage.synthesis, "Dyad", BurmesterDyad),
+]
+
+
+@pytest.mark.parametrize(("module", "name", "target"), ALIASES)
+def test_alias_warns_and_resolves(module, name, target):
+    """Reading a deprecated alias warns but returns the replacement."""
+    with pytest.warns(DeprecationWarning) as record:
+        assert getattr(module, name) is target
+
+    message = str(record[0].message)
+    assert f"{module.__name__}.{name}" in message
+    assert "2.0.0" in message
+
+
+@pytest.mark.parametrize(("module", "name", "target"), ALIASES)
+def test_alias_message_names_the_replacement(module, name, target):
+    """The warning tells the caller what to use instead."""
+    with pytest.warns(DeprecationWarning) as record:
+        getattr(module, name)
+
+    assert target.__name__ in str(record[0].message)
+
+
+def test_unknown_attribute_still_raises():
+    """The hook does not swallow genuine typos."""
+    with pytest.raises(AttributeError, match="no attribute 'Dyed'"):
+        pylinkage.dyads.Dyed  # noqa: B018
+
+
+def test_from_import_still_works():
+    """``from ... import Dyad`` keeps working, which is the whole promise."""
+    with pytest.warns(DeprecationWarning):
+        from pylinkage.dyads import Dyad
+
+    assert Dyad is Component
+
+
+def test_deprecated_names_stay_in_dunder_all():
+    """``import *`` must keep exporting them until they are removed."""
+    assert "Dyad" in pylinkage.dyads.__all__
+    assert "ConnectedDyad" in pylinkage.dyads.__all__
+    assert "Dyad" in pylinkage.components.__all__
+    assert "Dyad" in pylinkage.synthesis.__all__
+
+
+def test_no_warning_for_the_replacements():
+    """The names people should move to are silent."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert pylinkage.components.Component is Component
+        assert pylinkage.synthesis.BurmesterDyad is BurmesterDyad
+        assert pylinkage.dyads.RRRDyad is not None
+
+
+def test_the_three_dyads_are_distinct():
+    """The collision that motivated the rename is gone.
+
+    ``assur.Dyad`` is an Assur group, ``synthesis.BurmesterDyad`` a Burmester
+    construct, and the ``dyads``/``components`` aliases were never dyads at
+    all. Only one bare ``Dyad`` class remains.
+    """
+    assert AssurDyad is not BurmesterDyad
+    assert AssurDyad.__name__ == "Dyad"
+    assert BurmesterDyad.__name__ == "BurmesterDyad"
+    assert not hasattr(Component, "circle_point")


### PR DESCRIPTION
Closes the `Dyad` name collision that the last four documentation PRs kept running into, and writes down the deprecation policy #22 asks for.

## The problem

Three unrelated classes were reachable as `Dyad`, and only two of them were dyads:

| Name | What it is | Fate |
|---|---|---|
| `pylinkage.assur.Dyad` | An Assur group | Genuine dyad — **unaffected**, keeps its name |
| `pylinkage.synthesis.Dyad` | A Burmester dyad (circle point + center point) | Genuine, but a specific kind — renamed `BurmesterDyad` |
| `pylinkage.components.Dyad` / `ConnectedDyad` | Plain aliases of `Component` / `ConnectedComponent` | Never dyads — deprecated |
| `pylinkage.dyads.Dyad` / `ConnectedDyad` | The same aliases, re-exported | Never dyads — deprecated |

A `Ground` point is a `Component`. Calling it a dyad is simply wrong, and the alias made Sphinx resolve cross-references to whichever `Dyad` it found first — so a link on one class took you to another.

## Nothing breaks

Every deprecated name still resolves to the same object it always did, and stays in its module's `__all__`, so `import *` is unaffected. They are removed from the module namespace and served by a module-level `__getattr__` (PEP 562) instead, so reading one emits a `DeprecationWarning` while `from pylinkage.dyads import Dyad` resolves exactly as before.

Removal is scheduled for **2.0.0**.

`DeprecationWarning` is silent by default in Python, so no existing output changes.

## The policy, written down

`docs/source/deprecations.md` is new: what the project promises about public names (announce with a warning naming the replacement and removal release; remove no earlier than the next major version), the table of what is currently deprecated, a migration snippet, and how to surface the warnings. That is part of #22, not all of it — the API surface audit is still open.

## Verification

- 15 new tests in `tests/test_deprecations.py`: each alias warns, resolves to the right object, names its replacement, stays in `__all__`; unknown attributes still raise `AttributeError`; the replacements themselves are silent.
- 2463 passed, 5 skipped with all extras installed. That is exactly the previous 2448 plus these 15 — the 5 skips are pymoo/pandas/Groebner, unchanged.
- Lint and `mypy --strict` clean on 134 source files.
- Nothing in `leggedsnake` uses any of the deprecated names.

## Documentation build: 8 warnings to 0

This clears the last of them. For the record, across the recent run of PRs:

| Stage | Warnings |
|---|---:|
| Before #30 (12 of 18 subpackages undocumented) | 26 |
| After regenerating the API reference | 496 |
| After napoleon + docstring fixes | 76 |
| After README links | 38 |
| After the anchor annotation fix (#35) | 8 |
| **This PR** | **0** |

## Note on versioning

This adds a public name (`BurmesterDyad`), so the next release should be **1.2.0**, not a patch.