### PR TITLE
Cite the Zenodo concept DOI, and stop editing CITATION.cff by hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The cited DOI pointed at 1.0.0 and would have gone stale every release.**
+  `CITATION.cff` and the README badge carried `10.5281/zenodo.21207487`, the
+  *version* DOI Zenodo minted for 1.0.0. Zenodo also mints a *concept* DOI per
+  project — `10.5281/zenodo.21207486` here — which never changes and always
+  resolves to the newest version. Both now cite that instead, so neither needs
+  touching at release time; the 1.0.0 version DOI is kept as a second
+  identifier, since anything already citing it should keep resolving.
+
+- **`CITATION.cff` was bumped by hand.** Its `version` and `date-released` were
+  not in the bump-my-version file list, so every release depended on
+  remembering to edit them. They are now bumped automatically, the date from
+  `{now}`. `CONTRIBUTING.md`'s release section is corrected to match, and gains
+  the `uv lock` step it was missing — `uv.lock` records the project version and
+  bump-my-version does not touch it.
+
 ### Added
 
 - **`pylinkage.synthesis.BurmesterDyad`**, the new name for what was

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,9 @@ version: 1.1.1
 date-released: "2026-09-04"
 identifiers:
   - type: doi
+    value: "10.5281/zenodo.21207486"
+    description: "Concept DOI, always resolving to the latest released version"
+  - type: doi
     value: "10.5281/zenodo.21207487"
     description: "Zenodo archive of pylinkage v1.0.0"
 license: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,9 @@ This section is mainly intended for maintainers.
    uv run sphinx-build -b html docs/source docs/
    ```
 
-3. Bump the version (updates `pyproject.toml` and `src/pylinkage/__init__.py`, commits, and tags):
+3. Bump the version. This updates `pyproject.toml`, `src/pylinkage/__init__.py`
+   and `CITATION.cff` (both its `version` and its `date-released`), then commits
+   and tags:
 
    ```bash
    uv run bump-my-version bump patch  # For bug fixes (0.6.0 → 0.6.1)
@@ -101,7 +103,17 @@ This section is mainly intended for maintainers.
    uv run bump-my-version bump major  # For breaking changes (0.6.0 → 1.0.0)
    ```
 
-   Use `--dry-run` to preview changes without applying them.
+   Use `--dry-run --allow-dirty` to preview changes without applying them.
+
+   `uv.lock` records the project version too, and bump-my-version does not
+   touch it. Run `uv lock` and include the result in the bump commit:
+
+   ```bash
+   uv run bump-my-version bump patch --no-commit --no-tag
+   uv lock
+   git commit -am "chore: bump version X.Y.Z → X.Y.W"
+   git tag -a vX.Y.W -m "Release vX.Y.W"
+   ```
 
 4. Push the commit and tag:
 
@@ -111,6 +123,11 @@ This section is mainly intended for maintainers.
 
 5. Publish a new [GitHub release](https://github.com/HugoFara/pylinkage/releases).
    This triggers automatic PyPI publishing.
+
+   Zenodo mints a DOI for each release on its own, provided the repository is
+   enabled at [zenodo.org/account/settings/github](https://zenodo.org/account/settings/github).
+   Nothing needs editing afterwards: the DOI in `CITATION.cff` and the README
+   badge is the *concept* DOI, which always resolves to the newest version.
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads](https://static.pepy.tech/personalized-badge/pylinkage?period=total&units=international_system&left_color=grey&right_color=green&left_text=Downloads)](https://pepy.tech/project/pylinkage)
 [![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen)](https://codecov.io/gh/HugoFara/pylinkage)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg )](https://raw.githubusercontent.com/HugoFara/pylinkage/main/LICENSE.rst)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21207487.svg)](https://doi.org/10.5281/zenodo.21207487)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21207486.svg)](https://doi.org/10.5281/zenodo.21207486)
 
 Pylinkage lets you design [planar linkage mechanisms](https://en.wikipedia.org/wiki/Linkage_(mechanical)) by specifying the motion you need. Tell it where you want a coupler point to go, and it finds mechanism dimensions automatically using classical synthesis theory ([Burmester](https://en.wikipedia.org/wiki/Burmester_theory), [Freudenstein](https://en.wikipedia.org/wiki/Ferdinand_Freudenstein)) and metaheuristic optimization ([PSO](https://en.wikipedia.org/wiki/Particle_swarm_optimization), [differential evolution](https://en.wikipedia.org/wiki/Differential_evolution)). You can then simulate, analyze, visualize, and export to DXF or STEP for fabrication.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,3 +173,16 @@ replace = 'version = "{new_version}"'
 filename = "src/pylinkage/__init__.py"
 search = '__version__ = "{current_version}"'
 replace = '__version__ = "{new_version}"'
+
+# CITATION.cff carries the release version and date. Both were edited by hand
+# before; the DOI below it is the Zenodo concept DOI, which never changes.
+[[tool.bumpversion.files]]
+filename = "CITATION.cff"
+search = "version: {current_version}"
+replace = "version: {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "CITATION.cff"
+regex = true
+search = 'date-released: "[0-9-]+"'
+replace = 'date-released: "{now:%Y-%m-%d}"'


### PR DESCRIPTION
Two release-time chores that should not have been manual.

## The DOI was pinned to 1.0.0

`CITATION.cff` and the README badge both carried `10.5281/zenodo.21207487`. That is a **version DOI** — fixed to the 1.0.0 archive. It was already wrong at 1.1.0, and would need re-editing after every release forever.

Zenodo mints two kinds of DOI:

| | DOI | Resolves to |
|---|---|---|
| **Concept** | `10.5281/zenodo.21207486` | Always the newest version |
| Version | `10.5281/zenodo.21207487` | The 1.0.0 archive, permanently |

Both references now use the concept DOI, which is what Zenodo recommends citing when you mean "this software" rather than "this exact release". Verified live: `https://doi.org/10.5281/zenodo.21207486` returns 302 to the Zenodo record.

The 1.0.0 version DOI is kept as a second identifier in `CITATION.cff`, so anything already citing it keeps resolving.

## `CITATION.cff` was bumped by hand

Its `version` and `date-released` were not in the bump-my-version file list, so each release depended on remembering to edit them. Two new `[[tool.bumpversion.files]]` entries handle both, the date from `{now}`. Verified by dry run:

```
Found 'date-released: "[0-9-]+"' at line 11: date-released: "2020-01-01"
    ! date-released: "2020-01-01"
    ! date-released: "2026-09-04"
```

`CONTRIBUTING.md`'s release section said the bump touches `pyproject.toml` and `src/pylinkage/__init__.py`; it now names `CITATION.cff` too, and gains the `uv lock` step it was missing — `uv.lock` records the project version and bump-my-version does not touch it, which is why the 1.1.1 bump needed a manual `uv lock`.

## One thing this PR cannot do

**Zenodo archiving is not switched on for this repository.** The repo has no webhooks at all (`GET /repos/HugoFara/pylinkage/hooks` returns `[]`), and Zenodo lists exactly one version under the concept record:

```
total: 1
  1.0.0  10.5281/zenodo.21207487  2026-07-05
```

So v1.1.0 and v1.1.1 were never archived and have no DOI. Enabling it is a manual step at [zenodo.org/account/settings/github](https://zenodo.org/account/settings/github) — flip the switch for `HugoFara/pylinkage`. After that every GitHub Release is archived and gets a version DOI automatically, with no repository edits, because the concept DOI is what we now cite.

Note that Zenodo only archives releases published **after** the switch is on, so 1.1.1 will not be picked up retroactively; the next release would be the first archived one.