### PR TITLE
docs: correct what makes path_generation() slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The benchmarks page gave wrong advice about `path_generation()`.** It
+  attributed the cost to the orientation sweep and said lowering
+  `n_orientation_samples` trades coverage for time roughly linearly. Profiling
+  shows neither is true: verifying candidates by simulation is 67% of the
+  runtime and Burmester synthesis only 21%, and `n_orientation_samples` is
+  close to inert — the values 6, 12, 36 and 72 take the same time and return
+  the same ten solutions on the README's points, because the per-axis grid
+  resolution it feeds is floored at 6. The real control is `max_solutions`,
+  measured from 124 ms at 1 solution to 2316 ms for all 79. The page and the
+  `path_generation()` docstring now say so, and the page notes that cost
+  depends heavily on which points are asked for: two four-point problems
+  returning ten solutions each measured 336 ms and 1676 ms. Tracked in #29.
+
+### Fixed
+
 - **The cited DOI pointed at 1.0.0 and would have gone stale every release.**
   `CITATION.cff` and the README badge carried `10.5281/zenodo.21207487`, the
   *version* DOI Zenodo minted for 1.0.0. Zenodo also mints a *concept* DOI per

--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -81,7 +81,7 @@ Classical synthesis entry points, timed end to end.
 | Measurement | Median | Unit | Spread | Notes |
 |---|---:|---|---:|---|
 | `function_generation()` | 0.09 | ms | 27.8% | 3 angle pairs (Freudenstein); 1 solution |
-| `path_generation()` | 1778.63 | ms | 8.2% | 4 precision points, 36 orientation samples; 10 solutions |
+| `path_generation()` | 1778.63 | ms | 8.2% | 4 precision points, `max_solutions=10`; 10 solutions |
 | `motion_generation()` | 0.69 | ms | 6.3% | 3 poses; 10 solutions |
 
 The three differ by four orders of magnitude, and the reason is structural
@@ -92,13 +92,58 @@ rather than incidental:
 - **`motion_generation()`** applies Burmester theory to a fixed set of poses. The
   work is bounded by the number of poses.
 - **`path_generation()`** has no prescribed timing, so coupler orientation at
-  each precision point is a free variable. It searches over
-  `n_orientation_samples` candidate orientations (36 by default) and runs
-  Burmester synthesis for each, which is why it costs **well over a second**.
+  each precision point is a free variable. It searches candidate orientations,
+  runs Burmester synthesis for each, and then **verifies every surviving
+  candidate by simulating it**, which is why it costs **well over a second**.
 
-That last figure is worth knowing before you call `path_generation()` in a loop
-or behind an interactive control. If you need it faster, lowering
-`n_orientation_samples` trades solution coverage for time roughly linearly.
+### Where `path_generation()` spends its time
+
+Cost depends strongly on *which* points you ask for, not just how many. Both of
+these are four precision points returning ten solutions:
+
+| Precision points | Time |
+|---|---:|
+| `[(0,0), (1,1), (2,1), (3,0)]` (the README example) | 336 ms |
+| `[(0,1), (1,2), (2,1.5), (3,0)]` (benchmarked above) | 1676 ms |
+
+Points that admit solutions early are found early, and the search stops. The
+table at the top of this section reports the slower of the two, so treat it as
+an upper bound rather than a typical figure.
+
+Profiled on the README's points, the time splits as:
+
+| Stage | Share |
+|---|---:|
+| Verifying candidates by simulation (`step()`, 300 steps each) | 67% |
+| Burmester synthesis | 21% |
+
+Verification dominates. The search itself is comparatively cheap.
+
+That is also why **`max_solutions`** (default 10) is the knob that controls the
+cost — the search stops as soon as it has that many confirmed solutions.
+Measured on the README's points:
+
+| `max_solutions` | Time | Solutions |
+|---|---:|---:|
+| 1 | 124 ms | 1 |
+| 5 | 284 ms | 5 |
+| 10 (default) | 338 ms | 10 |
+| 20 | 1181 ms | 20 |
+| `None` | 2316 ms | 79 |
+
+If you need `path_generation()` faster — in a loop, or behind an interactive
+control — lower `max_solutions`. Asking for one solution instead of ten is
+roughly a third of the cost.
+
+```{note}
+`n_orientation_samples` is **not** an effective control, despite its name and
+what earlier versions of this page claimed. Measured on the four precision
+points above, the values 6, 12, 36 and 72 all take the same time and return the
+same ten solutions; on other point sets, lowering it returns *fewer* solutions
+without being faster. The parameter sets a per-axis grid resolution that is
+floored at 6, so it has no effect across most of its useful range. This is
+tracked in [#29](https://github.com/HugoFara/pylinkage/issues/29).
+```
 
 ## What is not benchmarked here
 

--- a/src/pylinkage/synthesis/path_generation.py
+++ b/src/pylinkage/synthesis/path_generation.py
@@ -406,7 +406,13 @@ def path_generation(
 
     For path generation without prescribed timing, the coupler
     orientation at each point is a free variable. This function
-    searches over orientation candidates using Burmester theory.
+    searches over orientation candidates using Burmester theory, then
+    verifies each surviving candidate by simulating it.
+
+    That verification, not the search, dominates the running time. A call
+    typically costs hundreds of milliseconds and can exceed a second, so
+    prefer not to place it inside a loop or behind an interactive control
+    without lowering ``max_solutions`` first.
 
     Args:
         precision_points: List of (x, y) points the coupler should pass through.
@@ -414,8 +420,15 @@ def path_generation(
         coupler_point_offset: Offset of traced point from coupler reference.
         ground_pivot_a: Optional fixed position for left ground pivot.
         ground_pivot_d: Optional fixed position for right ground pivot.
-        n_orientation_samples: Number of orientation samples to try.
+        n_orientation_samples: Requested resolution of the orientation search.
+            Note that this is currently a weak control: it sets a per-axis grid
+            resolution that is floored at 6, so values across most of its range
+            produce the same search. Prefer ``max_solutions`` to trade time
+            against coverage. See issue #29.
         max_solutions: Maximum number of solutions to return (None for all).
+            This is what governs the running time, since the search stops as
+            soon as it has this many *verified* solutions. Lowering it is the
+            effective way to make this function faster.
         require_grashof: If True, reject non-Grashof solutions.
         require_crank_rocker: If True, only accept crank-rocker type.
 


### PR DESCRIPTION
The benchmarks page told users the wrong thing about `path_generation()`, and I wrote it. Profiling for #29 shows both of its claims are false.

## What it said

> It searches over `n_orientation_samples` candidate orientations (36 by default) and runs Burmester synthesis for each, which is why it costs well over a second.
>
> If you need it faster, lowering `n_orientation_samples` trades solution coverage for time roughly linearly.

## What is actually true

**Verification dominates, not search.** Simulating each surviving candidate through `_verify_coupler_path` is **67%** of the runtime; Burmester synthesis is 21%.

**`n_orientation_samples` is close to inert.** It feeds:

```python
per_axis = max(6, int(round(n_samples ** (1.0 / free))))
```

With 4 precision points `free = 3`, so `n_samples**(1/3)` stays under 6 for every value up to 216 — the floor swallows the parameter. Its only other use is a cap of `n_samples * n_samples`, a quadratic cap on a grid of size `6**free`.

| `n_orientation_samples` | README points | benchmark points |
|---:|---:|---:|
| 6 | 338 ms, 10 solutions | 511 ms, **0 solutions** |
| 12 | 340 ms, 10 solutions | 1668 ms, 10 solutions |
| 36 (default) | 336 ms, 10 solutions | 1676 ms, 10 solutions |
| 72 | 337 ms, 10 solutions | 1679 ms, 10 solutions |

Lowering it does not buy time. It eventually just returns nothing.

**`max_solutions` is the real control**, since the search stops once it has that many *verified* solutions:

| `max_solutions` | Time | Solutions |
|---|---:|---:|
| 1 | 124 ms | 1 |
| 10 (default) | 338 ms | 10 |
| 20 | 1181 ms | 20 |
| `None` | 2316 ms | 79 |

**Cost depends on which points you ask for.** Two four-point problems, both returning ten solutions: 336 ms for the README's points, 1676 ms for the benchmark's. The headline table reports the slower one, so the page now frames it as an upper bound rather than a typical figure.

## Changes

- `docs/source/benchmarks.md`: replaces the wrong explanation with a breakdown of where the time goes, the `max_solutions` table, the point-set sensitivity, and a note that `n_orientation_samples` is not a working control.
- `path_generation()` docstring: says verification dominates, points users at `max_solutions`, and warns that `n_orientation_samples` is a weak control.

This documents current behaviour only. Whether `n_orientation_samples` should be repaired or removed is a decision for #29 — as is the fact that switching verification to `step_fast()` would collapse that 67%, which is blocked on #40.