### PR TITLE
fix(solver): give each dyad its own joint type, stop returning NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`step_fast()` silently returned NaN for every dyad except `RRRDyad`.**
+  `linkage_to_solver_data()` typed every dyad as `JOINT_REVOLUTE` and read
+  `distance1` / `distance2` off it. Only `RRRDyad` has those attributes, so a
+  `FixedDyad` — which has `distance` and `angle` — reached the solver as two
+  zero-radius circles that never intersect, and the joint plus everything
+  downstream of it came out `NaN`. No exception was raised: callers got a
+  full-shaped array of `NaN` where positions should be, while `step()`
+  computed the same mechanism correctly. Since a `FixedDyad` is how a traced
+  point is rigidly attached to a coupler link, this covered most mechanisms
+  worth simulating quickly, including everything `pylinkage.synthesis` emits.
+  The conversion now dispatches on the actual dyad class: `JOINT_FIXED` with
+  `(distance, angle)` for `FixedDyad`, `JOINT_PRISMATIC` with three parents for
+  `RRPDyad`, `JOINT_REVOLUTE` only for `RRRDyad`. Both were already implemented
+  in `solver/simulation.py` and simply unreachable. `PPDyad` and the cam
+  followers, which the solver cannot represent, now raise `NotImplementedError`
+  naming `step()` as the alternative rather than producing a wrong answer.
+  `update_solver_constraints()` shares the same table, so the two cannot drift.
+  `step()` and `step_fast()` now agree bit for bit on all three supported dyad
+  types, and are tested to.
+
+### Fixed
+
 - **The benchmarks page gave wrong advice about `path_generation()`.** It
   attributed the cost to the orientation sweep and said lowering
   `n_orientation_samples` trades coverage for time roughly linearly. Profiling

--- a/src/pylinkage/bridge/solver_conversion.py
+++ b/src/pylinkage/bridge/solver_conversion.py
@@ -13,11 +13,56 @@ import numpy as np
 
 from ..solver.types import (
     JOINT_CRANK,
+    JOINT_FIXED,
+    JOINT_PRISMATIC,
     JOINT_REVOLUTE,
     JOINT_STATIC,
     MAX_PARENTS,
     SolverData,
 )
+
+# How each dyad class maps onto the solver's numeric representation:
+# the joint type, the attributes holding its anchors (in the parent order the
+# solver expects), and the attributes holding its constraint values.
+#
+# Every dyad recognised by ``_compat.is_dyad`` must either appear here or be
+# rejected by ``_dyad_spec`` below. Silently treating one as another produces a
+# trajectory of NaN rather than an error, which is how ``FixedDyad`` went
+# unnoticed: it has ``distance``/``angle``, so reading ``distance1``/
+# ``distance2`` off it yielded two zero-radius circles that never intersect.
+_DYAD_SOLVER_SPECS: dict[str, tuple[int, tuple[str, ...], tuple[str, ...]]] = {
+    "RRRDyad": (JOINT_REVOLUTE, ("anchor1", "anchor2"), ("distance1", "distance2")),
+    "BinaryDyad": (JOINT_REVOLUTE, ("anchor1", "anchor2"), ("distance1", "distance2")),
+    "FixedDyad": (JOINT_FIXED, ("anchor1", "anchor2"), ("distance", "angle")),
+    "RRPDyad": (
+        JOINT_PRISMATIC,
+        ("revolute_anchor", "line_anchor1", "line_anchor2"),
+        ("distance",),
+    ),
+}
+
+
+def _dyad_spec(part: Any) -> tuple[int, tuple[str, ...], tuple[str, ...]]:
+    """Return the solver representation for a dyad.
+
+    Args:
+        part: The dyad component to represent.
+
+    Returns:
+        Its ``(joint_type, anchor_attrs, constraint_attrs)`` triple.
+
+    Raises:
+        NotImplementedError: If the numba solver cannot represent this dyad.
+    """
+    name = type(part).__name__
+    spec = _DYAD_SOLVER_SPECS.get(name)
+    if spec is None:
+        raise NotImplementedError(
+            f"The numba solver cannot represent {name}. Use Linkage.step() "
+            f"instead of step_fast() for this mechanism. Supported dyads: "
+            f"{', '.join(sorted(_DYAD_SOLVER_SPECS))}."
+        )
+    return spec
 
 
 def linkage_to_solver_data(linkage: Any) -> SolverData:
@@ -84,8 +129,9 @@ def linkage_to_solver_data(linkage: Any) -> SolverData:
             counts.append(2)
 
         elif is_dyad(part):
-            joint_types[i] = JOINT_REVOLUTE
-            for p_idx, attr in enumerate(("anchor1", "anchor2")):
+            joint_type, anchor_attrs, constraint_attrs = _dyad_spec(part)
+            joint_types[i] = joint_type
+            for p_idx, attr in enumerate(anchor_attrs):
                 parent = getattr(part, attr, None)
                 if parent is None:
                     continue
@@ -94,11 +140,10 @@ def linkage_to_solver_data(linkage: Any) -> SolverData:
                 idx = part_to_idx.get(id(actual))
                 if idx is not None:
                     parent_indices[i, p_idx] = idx
-            d1 = getattr(part, "distance1", 0.0)
-            d2 = getattr(part, "distance2", 0.0)
-            constraints_list.append(d1)
-            constraints_list.append(d2)
-            counts.append(2)
+            for attr in constraint_attrs:
+                value = getattr(part, attr, None)
+                constraints_list.append(float(value) if value is not None else 0.0)
+            counts.append(len(constraint_attrs))
 
         else:
             joint_types[i] = JOINT_STATIC
@@ -297,21 +342,12 @@ def update_solver_constraints(data: SolverData, linkage: Any) -> None:
             data.constraints[offset] = radius if radius is not None else 0.0
             data.constraints[offset + 1] = omega if omega is not None else 0.0
 
-        elif name == "RRRDyad":
-            d1 = getattr(part, "distance1", 0.0)
-            d2 = getattr(part, "distance2", 0.0)
-            data.constraints[offset] = d1 if d1 is not None else 0.0
-            data.constraints[offset + 1] = d2 if d2 is not None else 0.0
-
-        elif name == "FixedDyad":
-            r = getattr(part, "distance", 0.0)
-            a = getattr(part, "angle", 0.0)
-            data.constraints[offset] = r if r is not None else 0.0
-            data.constraints[offset + 1] = a if a is not None else 0.0
-
-        elif name == "RRPDyad":
-            rr = getattr(part, "distance1", 0.0)
-            data.constraints[offset] = rr if rr is not None else 0.0
+        elif name in _DYAD_SOLVER_SPECS:
+            # Same spec as linkage_to_solver_data, so the two cannot drift.
+            _, _, constraint_attrs = _DYAD_SOLVER_SPECS[name]
+            for k, attr in enumerate(constraint_attrs):
+                value = getattr(part, attr, None)
+                data.constraints[offset + k] = float(value) if value is not None else 0.0
 
 
 def update_solver_positions(data: SolverData, linkage: Any) -> None:

--- a/tests/simulation/test_step_fast_agreement.py
+++ b/tests/simulation/test_step_fast_agreement.py
@@ -1,0 +1,154 @@
+"""``Linkage.step_fast()`` must agree with ``Linkage.step()``, dyad by dyad.
+
+Before this suite existed, ``linkage_to_solver_data`` typed every dyad as
+``JOINT_REVOLUTE`` and read ``distance1``/``distance2`` off it. Only ``RRRDyad``
+has those attributes, so a ``FixedDyad`` reached the solver as two zero-radius
+circles and produced a trajectory of ``NaN`` -- silently, with no exception. The
+bridge tests covered the ``RRRDyad`` path, and nothing compared the two
+simulation paths for anything else.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pylinkage.actuators import Crank
+from pylinkage.components import Ground
+from pylinkage.dyads import FixedDyad, PPDyad, RRPDyad, RRRDyad
+from pylinkage.simulation import Linkage
+
+ITERATIONS = 12
+
+
+def make_fourbar() -> Linkage:
+    """Crank plus an RRR dyad: the only case the solver ever handled."""
+    anchor = Ground(0.0, 0.0, name="A")
+    frame = Ground(3.0, 0.0, name="D")
+    crank = Crank(anchor=anchor, radius=1.0, angular_velocity=0.31, name="B")
+    rocker = RRRDyad(
+        anchor1=crank.output, anchor2=frame, distance1=3.0, distance2=1.5, name="C"
+    )
+    return Linkage([anchor, frame, crank, rocker], name="fourbar")
+
+
+def make_fourbar_with_coupler_point() -> Linkage:
+    """A four-bar carrying a coupler point, which is what synthesis emits."""
+    anchor = Ground(0.0, 0.0, name="A")
+    frame = Ground(3.0, 0.0, name="D")
+    crank = Crank(anchor=anchor, radius=1.0, angular_velocity=0.31, name="B")
+    rocker = RRRDyad(
+        anchor1=crank.output, anchor2=frame, distance1=3.0, distance2=1.5, name="C"
+    )
+    coupler_point = FixedDyad(
+        anchor1=crank.output, anchor2=rocker, distance=1.4, angle=-0.37, name="P"
+    )
+    return Linkage([anchor, frame, crank, rocker, coupler_point], name="coupler")
+
+
+def make_crank_slider() -> Linkage:
+    """A slider on a horizontal rail.
+
+    ``distance`` exceeds the largest crank-tip-to-rail distance (3.0), so the
+    circle meets the line at every crank angle and the mechanism stays
+    buildable through a full revolution.
+    """
+    anchor = Ground(0.0, 0.0, name="A")
+    rail_start = Ground(0.0, -2.0, name="L1")
+    rail_end = Ground(5.0, -2.0, name="L2")
+    crank = Crank(anchor=anchor, radius=1.0, angular_velocity=0.31, name="B")
+    slider = RRPDyad(
+        revolute_anchor=crank.output,
+        line_anchor1=rail_start,
+        line_anchor2=rail_end,
+        distance=3.5,
+        name="S",
+    )
+    return Linkage([anchor, rail_start, rail_end, crank, slider], name="slider")
+
+
+def trajectory_via_step(linkage: Linkage) -> np.ndarray:
+    """Collect ``step()`` output in the same shape ``step_fast()`` returns."""
+    return np.array(
+        [list(positions) for positions in linkage.step(iterations=ITERATIONS)],
+        dtype=float,
+    )
+
+
+BUILDERS = [
+    pytest.param(make_fourbar, id="RRRDyad"),
+    pytest.param(make_fourbar_with_coupler_point, id="FixedDyad"),
+    pytest.param(make_crank_slider, id="RRPDyad"),
+]
+
+
+@pytest.mark.parametrize("builder", BUILDERS)
+def test_step_fast_matches_step(builder):
+    """The two simulation paths agree to floating-point exactness.
+
+    Both call the same ``solve_*`` functions, so anything other than an exact
+    match means the conversion handed the solver different numbers.
+    """
+    slow = trajectory_via_step(builder())
+    fast = builder().step_fast(iterations=ITERATIONS)
+
+    assert fast.shape == slow.shape
+    np.testing.assert_allclose(fast, slow, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("builder", BUILDERS)
+def test_step_fast_produces_no_nan(builder):
+    """A NaN trajectory is the failure mode this suite exists to catch."""
+    fast = builder().step_fast(iterations=ITERATIONS)
+    assert np.isfinite(fast).all()
+
+
+def test_unsupported_dyad_raises_instead_of_returning_nan():
+    """``PPDyad`` has four anchors, one more than the solver can carry.
+
+    It must say so rather than emit a wrong joint type, which is what produced
+    silent NaN before.
+    """
+    a = Ground(0.0, 0.0, name="A")
+    b = Ground(4.0, 0.0, name="B")
+    c = Ground(0.0, 1.0, name="C")
+    d = Ground(4.0, 3.0, name="D")
+    crank = Crank(anchor=a, radius=1.0, angular_velocity=0.31, name="crank")
+    intersection = PPDyad(
+        line1_anchor1=crank.output,
+        line1_anchor2=b,
+        line2_anchor1=c,
+        line2_anchor2=d,
+        name="X",
+    )
+    linkage = Linkage([a, b, c, d, crank, intersection], name="pp")
+
+    with pytest.raises(NotImplementedError, match="PPDyad"):
+        linkage.step_fast(iterations=3)
+
+
+def test_unsupported_dyad_error_names_the_alternative():
+    """The message has to tell the caller what to do instead."""
+    a = Ground(0.0, 0.0)
+    b = Ground(4.0, 0.0)
+    c = Ground(0.0, 1.0)
+    d = Ground(4.0, 3.0)
+    crank = Crank(anchor=a, radius=1.0, angular_velocity=0.31)
+    linkage = Linkage(
+        [
+            a,
+            b,
+            c,
+            d,
+            crank,
+            PPDyad(
+                line1_anchor1=crank.output,
+                line1_anchor2=b,
+                line2_anchor1=c,
+                line2_anchor2=d,
+            ),
+        ]
+    )
+
+    with pytest.raises(NotImplementedError, match=r"step\(\)"):
+        linkage.step_fast(iterations=3)

--- a/tests/test_bridge_solver_conversion.py
+++ b/tests/test_bridge_solver_conversion.py
@@ -15,10 +15,12 @@ from pylinkage.bridge import (
     update_solver_positions,
 )
 from pylinkage.components import Ground
-from pylinkage.dyads import FixedDyad, RRRDyad
+from pylinkage.dyads import FixedDyad, PPDyad, RRPDyad, RRRDyad
 from pylinkage.simulation import Linkage
 from pylinkage.solver.types import (
     JOINT_CRANK,
+    JOINT_FIXED,
+    JOINT_PRISMATIC,
     JOINT_REVOLUTE,
     JOINT_STATIC,
     SolverData,
@@ -58,6 +60,21 @@ def make_fourbar_with_fixed():
         name="fixed",
     )
     return Linkage([O1, O2, crank, rocker, fixed], name="FourBarFixed")
+
+
+def make_crank_slider():
+    A = Ground(0.0, 0.0, name="A")
+    L1 = Ground(0.0, -2.0, name="L1")
+    L2 = Ground(5.0, -2.0, name="L2")
+    crank = Crank(anchor=A, radius=1.0, angular_velocity=0.1, name="crank")
+    slider = RRPDyad(
+        revolute_anchor=crank.output,
+        line_anchor1=L1,
+        line_anchor2=L2,
+        distance=3.5,
+        name="slider",
+    )
+    return Linkage([A, L1, L2, crank, slider], name="CrankSlider")
 
 
 class TestLinkageToSolverData:
@@ -106,6 +123,60 @@ class TestLinkageToSolverData:
         linkage = make_fourbar_with_fixed()
         data = linkage_to_solver_data(linkage)
         assert data.positions.shape == (5, 2)
+
+    def test_fixed_dyad_keeps_its_own_joint_type(self):
+        """A FixedDyad is a polar projection, not a circle-circle intersection.
+
+        Typing it as JOINT_REVOLUTE made the solver intersect two circles of
+        radius zero, which never meet, so the joint came out NaN.
+        """
+        linkage = make_fourbar_with_fixed()
+        data = linkage_to_solver_data(linkage)
+        assert data.joint_types[4] == JOINT_FIXED
+
+    def test_fixed_dyad_carries_distance_and_angle(self):
+        """Its constraints are (distance, angle), not (distance1, distance2)."""
+        linkage = make_fourbar_with_fixed()
+        data = linkage_to_solver_data(linkage)
+        offset = data.constraint_offsets[4]
+        assert data.constraints[offset] == pytest.approx(0.5)
+        assert data.constraints[offset + 1] == pytest.approx(math.pi / 4)
+
+    def test_rrp_dyad_is_prismatic_with_three_parents(self):
+        """A slider needs a circle centre plus two points defining the line."""
+        linkage = make_crank_slider()
+        data = linkage_to_solver_data(linkage)
+        assert data.joint_types[4] == JOINT_PRISMATIC
+        assert (data.parent_indices[4] >= 0).sum() == 3
+
+    def test_rrp_dyad_carries_one_constraint(self):
+        linkage = make_crank_slider()
+        data = linkage_to_solver_data(linkage)
+        offset = data.constraint_offsets[4]
+        assert data.constraint_counts[4] == 1
+        assert data.constraints[offset] == pytest.approx(3.5)
+
+    def test_unsupported_dyad_raises(self):
+        """PPDyad has four anchors; MAX_PARENTS is three.
+
+        Emitting a wrong joint type for it would be silently wrong, so the
+        conversion refuses instead.
+        """
+        A = Ground(0.0, 0.0)
+        B = Ground(4.0, 0.0)
+        C = Ground(0.0, 1.0)
+        D = Ground(4.0, 3.0)
+        crank = Crank(anchor=A, radius=1.0, angular_velocity=0.1)
+        pp = PPDyad(
+            line1_anchor1=crank.output,
+            line1_anchor2=B,
+            line2_anchor1=C,
+            line2_anchor2=D,
+        )
+        linkage = Linkage([A, B, C, D, crank, pp])
+
+        with pytest.raises(NotImplementedError, match="PPDyad"):
+            linkage_to_solver_data(linkage)
 
 
 class TestSolverDataToLinkage:
@@ -174,6 +245,14 @@ class TestUpdateSolverConstraints:
         offset = data.constraint_offsets[4]
         assert data.constraints[offset] == pytest.approx(0.75)
         assert data.constraints[offset + 1] == pytest.approx(1.0)
+
+    def test_update_rrp_dyad(self):
+        linkage = make_crank_slider()
+        data = linkage_to_solver_data(linkage)
+        linkage.components[4].distance = 4.25
+        update_solver_constraints(data, linkage)
+        offset = data.constraint_offsets[4]
+        assert data.constraints[offset] == pytest.approx(4.25)
 
 
 class TestUpdateSolverPositions:


### PR DESCRIPTION
Closes #40.

## The bug

`linkage_to_solver_data()` typed **every** dyad as `JOINT_REVOLUTE` and read `distance1` / `distance2` off it:

```python
elif is_dyad(part):
    joint_types[i] = JOINT_REVOLUTE
    ...
    d1 = getattr(part, "distance1", 0.0)
    d2 = getattr(part, "distance2", 0.0)
```

`is_dyad()` matches seven classes; only `RRRDyad` has those attributes. A `FixedDyad` has `distance` and `angle`, so both `getattr` calls fell through to `0.0` and the solver intersected two zero-radius circles. They never meet, so the joint — and everything solved downstream of it — came out `NaN`.

Nothing raised. Callers got a full-shaped array of `NaN` where positions should be, while `step()` computed the same mechanism correctly.

## Before / after

```python
P = FixedDyad(anchor1=crank.output, anchor2=C, distance=1.4, angle=-0.37)
```

| | before | after |
|---|---|---|
| `step_fast()` P | `[nan, nan]` | `[2.3512, 0.2476]` |
| P joint type | `2` (`JOINT_REVOLUTE`) | `3` (`JOINT_FIXED`) |
| P constraints | `[0.0, 0.0]` | `[1.4, -0.37]` |

`step()` gives `(2.3512, 0.2476)` — the two paths now agree.

## The fix

`JOINT_FIXED` and `JOINT_PRISMATIC` were already defined in `solver/types.py` and handled in `solver/simulation.py`, and `update_solver_constraints()` even had a correct `FixedDyad` branch. The primary builder simply never emitted those types, so all of it was unreachable.

The conversion now dispatches on the actual dyad class through one table:

| Dyad | Joint type | Parents | Constraints |
|---|---|---|---|
| `RRRDyad`, `BinaryDyad` | `JOINT_REVOLUTE` | `anchor1`, `anchor2` | `distance1`, `distance2` |
| `FixedDyad` | `JOINT_FIXED` | `anchor1`, `anchor2` | `distance`, `angle` |
| `RRPDyad` | `JOINT_PRISMATIC` | `revolute_anchor`, `line_anchor1`, `line_anchor2` | `distance` |

`update_solver_constraints()` reads the same table, so the two cannot drift apart again.

`PPDyad` needs four parents against `MAX_PARENTS` of three, and the cam followers have no solver representation at all. Rather than being mistyped into a wrong answer, they now raise:

```
NotImplementedError: The numba solver cannot represent PPDyad. Use Linkage.step()
instead of step_fast() for this mechanism. Supported dyads: BinaryDyad, FixedDyad,
RRPDyad, RRRDyad.
```

`RRPDyad` was broken the same way and works now too — that one was never reported.

## Verification

`step()` against `step_fast()`, twelve iterations, `atol=0`:

| Mechanism | finite | max &#124;step − step_fast&#124; |
|---|---|---:|
| RRRDyad four-bar | yes | 0.0 |
| FixedDyad coupler point | yes | 0.0 |
| RRPDyad crank-slider | yes | 0.0 |

Both paths call the same `solve_*` functions, so anything but an exact match would mean the conversion handed the solver different numbers.

14 new tests: 8 in `tests/simulation/test_step_fast_agreement.py` (agreement and no-NaN per dyad type, plus the rejection and its message), 6 extending the bridge tests. Full suite 2477 passed, 5 skipped with all extras. Lint and `mypy --strict` clean on 134 files.

**How it went unnoticed:** the only `step()`/`step_fast()` agreement test covered the `Mechanism` path, and the bridge test named `test_with_fixed_dyad` asserted an array *shape* and nothing else.

## Effect on #29

With the solver fixed, routing `_verify_coupler_path` through `step_fast()` now works and returns real solutions:

| Precision points | `step()` | `step_fast()` | |
|---|---:|---:|---:|
| README | 343 ms | 169 ms | 2.0x |
| benchmark | 1718 ms | 593 ms | 2.9x |

2.9x is essentially the Amdahl ceiling for a stage that was 67% of runtime.

One caveat for whoever picks up #29, found while measuring: on the benchmark's points the two produce *different* sets of ten solutions. `step()` raises `UnbuildableError` on a candidate that cannot assemble and the caller treats that as rejection, whereas `step_fast()` returns `NaN` rows instead. A straight swap changes which candidates are accepted, so the rejection path needs handling deliberately. That is out of scope here.

## Known gap left open

`_mechanism_to_solver_data()` — the separate `Mechanism` path — still treats `PrismaticJoint` as `JOINT_STATIC`, with a comment saying prismatic kinematics "are not yet wired". That is a documented limitation rather than a silent mistype, and it is untouched here.