### PR TITLE
perf(synthesis): verify path candidates through the numba solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`path_generation()` is 2-8x faster**, with byte-identical results. Verifying
+  a candidate by simulating it was 67% of the runtime, and ran through the
+  pure-Python `Linkage.step()`; it now uses the numba solver, which executes the
+  same `solve_*` functions roughly twenty times faster. Measured end to end:
+
+  | Precision points | Before | After |
+  |---|---:|---:|
+  | README example | 345 ms | 163 ms |
+  | Benchmarked example | 1689 ms | 678 ms |
+  | Three points | 430 ms | 55 ms |
+
+  The two paths report an unassemblable mechanism differently — `step()` raises,
+  the solver writes `NaN` — so a naive switch would silently change which
+  candidates survive. Both are treated as rejection, and the solution sets are
+  verified identical across six point sets. `step()` is still used when numba is
+  absent or the mechanism contains a component the solver cannot represent.
+  This became possible only once `step_fast()` stopped returning `NaN` for
+  `FixedDyad`, the component carrying the coupler point.
+
+- **`Linkage.step()` is about a quarter faster** — 257,550 to 325,718 steps/s on
+  the reference four-bar — which speeds up every simulation, not only synthesis.
+  Two things in the innermost loop: `step()` re-ran `isinstance(component,
+  (Crank, ArcCrank, LinearActuator))` for every component on every iteration
+  although the classification is a property of the solve order, and
+  `_get_anchor_position` ran an `isinstance` check against an abstract base
+  class whose two branches returned the same expression. The published
+  `step_fast()` speedup falls from 6.4x to 5.1x as a result: the numerator got
+  faster, the solver did not regress.
+
+### Fixed
+
+- **The benchmarks page figures are regenerated** against the above, and its
+  breakdown of `path_generation()` is rewritten: Burmester synthesis over the
+  orientation grid is now 87% of the runtime and verification under 10%, the
+  reverse of what the page described. It also now warns that cost grows
+  exponentially in the number of precision points — five points can take seconds
+  and return nothing — which no documentation said.
+
 ### Fixed
 
 - **`step_fast()` silently returned NaN for every dyad except `RRRDyad`.**

--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -43,13 +43,16 @@ Simulating the reference four-bar (two grounds, a crank, and an `RRRDyad`).
 
 | Measurement | Median | Unit | Spread | Notes |
 |---|---:|---|---:|---|
-| `Linkage.step()` | 257,550 | steps/s | 9.8% | pure-Python generator |
-| `Linkage.step_fast()` | 1,658,608 | steps/s | 4.6% | numba JIT, compilation excluded by warmup |
-| `step_fast()` speedup | 6.4 | x | — | ratio of the two medians above |
+| `Linkage.step()` | 325,718 | steps/s | 10.8% | pure-Python generator |
+| `Linkage.step_fast()` | 1,675,768 | steps/s | 2.0% | numba JIT, compilation excluded by warmup |
+| `step_fast()` speedup | 5.1 | x | — | ratio of the two medians above |
 
-`step_fast()` is the numba-backed path and is roughly **6x faster** on this
+`step_fast()` is the numba-backed path and is roughly **5x faster** on this
 mechanism. The gap is what makes optimisation practical: an optimiser run spends
 essentially all of its time inside the solver.
+
+The ratio was 6.4x in earlier releases. It narrowed because `step()` itself got
+about a quarter faster, not because the solver regressed.
 
 Note that `step_fast()` pays JIT compilation on its first call. That cost is
 excluded here because it is paid once per process, but it is the reason a single
@@ -62,17 +65,18 @@ so the figure reflects the optimiser and solver rather than the objective.
 
 | Measurement | Median | Unit | Spread | Notes |
 |---|---:|---|---:|---|
-| `particle_swarm_optimization()` | 15,814 | evaluations/s | 33.2% | 100 particles x 100 iterations |
-| Full optimisation run | 0.639 | s | 29.6% | ~10,100 fitness evaluations |
+| `particle_swarm_optimization()` | 20,117 | evaluations/s | 72.3% | 100 particles x 100 iterations |
+| Full optimisation run | 0.502 | s | 59.1% | ~10,100 fitness evaluations |
 
 Evaluations are counted at the fitness function itself rather than inferred from
 `n_particles * iterations`, so the figure stays correct even if the swarm's
 internal call pattern changes.
 
-The spread here is wider than elsewhere because a sub-second run is sensitive to
-CPU frequency scaling. The useful takeaway is the order of magnitude: **roughly
-ten thousand fitness evaluations per second** on a four-bar, meaning a realistic
-optimisation budget is dominated by how expensive *your* fitness function is.
+The spread here is much wider than elsewhere -- it is the least trustworthy
+number on this page -- because a half-second run is dominated by CPU frequency
+scaling. Read the order of magnitude and nothing finer: **on the order of ten
+thousand fitness evaluations per second** on a four-bar, meaning a realistic
+optimisation budget is governed by how expensive *your* fitness function is.
 
 ## Synthesis
 
@@ -80,9 +84,9 @@ Classical synthesis entry points, timed end to end.
 
 | Measurement | Median | Unit | Spread | Notes |
 |---|---:|---|---:|---|
-| `function_generation()` | 0.09 | ms | 27.8% | 3 angle pairs (Freudenstein); 1 solution |
-| `path_generation()` | 1778.63 | ms | 8.2% | 4 precision points, `max_solutions=10`; 10 solutions |
-| `motion_generation()` | 0.69 | ms | 6.3% | 3 poses; 10 solutions |
+| `function_generation()` | 0.07 | ms | 72.6% | 3 angle pairs (Freudenstein); 1 solution |
+| `path_generation()` | 677.35 | ms | 0.7% | 4 precision points, `max_solutions=10`; 10 solutions |
+| `motion_generation()` | 0.66 | ms | 3.6% | 3 poses; 10 solutions |
 
 The three differ by four orders of magnitude, and the reason is structural
 rather than incidental:
@@ -92,9 +96,9 @@ rather than incidental:
 - **`motion_generation()`** applies Burmester theory to a fixed set of poses. The
   work is bounded by the number of poses.
 - **`path_generation()`** has no prescribed timing, so coupler orientation at
-  each precision point is a free variable. It searches candidate orientations,
-  runs Burmester synthesis for each, and then **verifies every surviving
-  candidate by simulating it**, which is why it costs **well over a second**.
+  each precision point is a free variable. It runs Burmester synthesis once per
+  candidate orientation, over a grid that grows exponentially with the number of
+  precision points, which is why it costs **hundreds of milliseconds**.
 
 ### Where `path_generation()` spends its time
 
@@ -103,8 +107,8 @@ these are four precision points returning ten solutions:
 
 | Precision points | Time |
 |---|---:|
-| `[(0,0), (1,1), (2,1), (3,0)]` (the README example) | 336 ms |
-| `[(0,1), (1,2), (2,1.5), (3,0)]` (benchmarked above) | 1676 ms |
+| `[(0,0), (1,1), (2,1), (3,0)]` (the README example) | 164 ms |
+| `[(0,1), (1,2), (2,1.5), (3,0)]` (benchmarked above) | 685 ms |
 
 Points that admit solutions early are found early, and the search stops. The
 table at the top of this section reports the slower of the two, so treat it as
@@ -114,26 +118,35 @@ Profiled on the README's points, the time splits as:
 
 | Stage | Share |
 |---|---:|
-| Verifying candidates by simulation (`step()`, 300 steps each) | 67% |
-| Burmester synthesis | 21% |
+| Burmester synthesis over the orientation grid | 87% |
+| Verifying candidates by simulation | 9% |
 
-Verification dominates. The search itself is comparatively cheap.
+The search dominates. Verification used to be 67% of the runtime; it now runs
+through the numba solver, which is why it no longer does.
 
-That is also why **`max_solutions`** (default 10) is the knob that controls the
-cost — the search stops as soon as it has that many confirmed solutions.
-Measured on the README's points:
+**`max_solutions`** (default 10) is the knob that controls the cost, because the
+search stops as soon as it has that many confirmed solutions. Measured on the
+README's points:
 
 | `max_solutions` | Time | Solutions |
 |---|---:|---:|
-| 1 | 124 ms | 1 |
-| 5 | 284 ms | 5 |
-| 10 (default) | 338 ms | 10 |
-| 20 | 1181 ms | 20 |
-| `None` | 2316 ms | 79 |
+| 1 | 87 ms | 1 |
+| 5 | 129 ms | 5 |
+| 10 (default) | 165 ms | 10 |
+| 20 | 550 ms | 20 |
+| `None` | 1108 ms | 79 |
 
 If you need `path_generation()` faster — in a loop, or behind an interactive
 control — lower `max_solutions`. Asking for one solution instead of ten is
-roughly a third of the cost.
+roughly half the cost.
+
+```{warning}
+Cost grows **exponentially in the number of precision points**, because the
+orientation grid is searched over one free angle per point after the first. Five
+points can take several seconds and still return nothing. Three or four points
+are the practical range, as the docstring's "best results with 3-5 points"
+implies more gently than the timings warrant.
+```
 
 ```{note}
 `n_orientation_samples` is **not** an effective control, despite its name and
@@ -141,8 +154,13 @@ what earlier versions of this page claimed. Measured on the four precision
 points above, the values 6, 12, 36 and 72 all take the same time and return the
 same ten solutions; on other point sets, lowering it returns *fewer* solutions
 without being faster. The parameter sets a per-axis grid resolution that is
-floored at 6, so it has no effect across most of its useful range. This is
-tracked in [#29](https://github.com/HugoFara/pylinkage/issues/29).
+floored at 6, so it has no effect across most of its useful range.
+
+Making it mean what its name says -- roughly that many candidate orientations in
+total -- was measured and rejected: it loses solutions. On three of six test
+point sets the search then returned nothing where it previously found ten. The
+dense grid earns its cost, so only the name and the documentation were ever
+wrong. Tracked in [#29](https://github.com/HugoFara/pylinkage/issues/29).
 ```
 
 ## What is not benchmarked here

--- a/src/pylinkage/dyads/_base.py
+++ b/src/pylinkage/dyads/_base.py
@@ -48,12 +48,15 @@ class BinaryDyad(ConnectedComponent):
     ) -> tuple[float | None, float | None]:
         """Get the position of an anchor.
 
+        Both a Component and an _AnchorProxy expose ``position``, so no
+        dispatch is needed. This runs once per anchor per simulation step,
+        which is often enough that the removed isinstance check against an
+        abstract base class was measurable.
+
         Args:
             anchor: Either a Component or an _AnchorProxy.
 
         Returns:
             The (x, y) position of the anchor.
         """
-        if isinstance(anchor, _AnchorProxy):
-            return anchor.position
         return anchor.position

--- a/src/pylinkage/simulation/linkage.py
+++ b/src/pylinkage/simulation/linkage.py
@@ -204,13 +204,22 @@ class Linkage:
         if iterations is None:
             iterations = self.get_rotation_period()
 
+        # Whether a component is actuator-driven is a property of the solve
+        # order, not of the step, so classify once rather than on every
+        # component on every iteration.
+        plan = [
+            (component, isinstance(component, (Crank, ArcCrank, LinearActuator)))
+            for component in self._solve_order
+        ]
+        components = self.components
+
         for _ in range(iterations):
-            for component in self._solve_order:
-                if isinstance(component, (Crank, ArcCrank, LinearActuator)):
+            for component, is_actuator in plan:
+                if is_actuator:
                     component.reload(dt)
                 else:
                     component.reload()
-            yield tuple(d.position for d in self.components)
+            yield tuple(d.position for d in components)
 
     def get_rotation_period(self) -> int:
         """Return number of steps for one full cycle.

--- a/src/pylinkage/synthesis/path_generation.py
+++ b/src/pylinkage/synthesis/path_generation.py
@@ -34,8 +34,10 @@ from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy import linalg as scipy_linalg
 
+from .._numba_compat import HAS_NUMBA
 from ._types import FourBarSolution, Point2D, Pose, PrecisionPoint, SynthesisType
 from .burmester import (
     complex_to_point,
@@ -289,6 +291,56 @@ def _filter_solutions(
     return valid, warnings
 
 
+def _coupler_trajectory(linkage: Linkage, iterations: int) -> NDArray[np.float64] | None:
+    """Trace the coupler point over one rotation.
+
+    Prefers the numba solver, which runs the same ``solve_*`` functions as
+    :meth:`Linkage.step` roughly twenty times faster, and falls back to
+    ``step()`` when numba is absent or the mechanism uses a component the
+    solver cannot represent.
+
+    The two paths report an unassemblable mechanism differently: ``step()``
+    raises, while the solver writes ``NaN``. Both are treated as failure here,
+    so the accept/reject decision does not depend on which path ran.
+
+    Args:
+        linkage: Linkage whose last component is the traced point.
+        iterations: Number of simulation steps.
+
+    Returns:
+        An ``(iterations, 2)`` array of traced-point positions, or None if the
+        linkage could not be simulated through a full rotation.
+    """
+    if HAS_NUMBA:
+        try:
+            trajectory = linkage.step_fast(iterations=iterations)
+        except NotImplementedError:
+            # A component the solver cannot represent. Use the Python path.
+            pass
+        except Exception:
+            # Anything else is a failed candidate, as it is for step().
+            return None
+        else:
+            # A NaN anywhere means the mechanism failed to assemble at some
+            # crank angle, which is what step() signals by raising.
+            if not np.isfinite(trajectory).all():
+                return None
+            return np.asarray(trajectory[:, -1, :], dtype=np.float64)
+
+    try:
+        points: list[tuple[float, float]] = []
+        for positions in linkage.step(iterations=iterations):
+            px, py = positions[-1]  # P is the last joint
+            if px is not None and py is not None:
+                points.append((px, py))
+    except Exception:
+        return None
+
+    if not points:
+        return None
+    return np.asarray(points, dtype=np.float64)
+
+
 def _verify_coupler_path(
     solution: FourBarSolution,
     precision_points: list[PrecisionPoint],
@@ -299,6 +351,9 @@ def _verify_coupler_path(
 
     Builds a temporary linkage, simulates one full rotation, and verifies
     that each precision point has a nearby point on the coupler trajectory.
+
+    Simulation runs through the numba solver where it can, which took this
+    from 67% of :func:`path_generation`'s runtime down to under 10%.
 
     Args:
         solution: Candidate four-bar solution.
@@ -327,20 +382,10 @@ def _verify_coupler_path(
     except Exception:
         return False
 
-    # Simulate and collect coupler point trajectory
-    try:
-        trajectory: list[tuple[float, float]] = []
-        for positions in lk.step(iterations=iterations):
-            px, py = positions[-1]  # P is the last joint
-            if px is not None and py is not None:
-                trajectory.append((px, py))
-    except Exception:
+    traj_arr = _coupler_trajectory(lk, iterations)
+    if traj_arr is None:
         return False
 
-    if not trajectory:
-        return False
-
-    traj_arr = np.asarray(trajectory)
     for px, py in precision_points:
         dists = np.hypot(traj_arr[:, 0] - px, traj_arr[:, 1] - py)
         if dists.min() > tolerance:
@@ -409,10 +454,11 @@ def path_generation(
     searches over orientation candidates using Burmester theory, then
     verifies each surviving candidate by simulating it.
 
-    That verification, not the search, dominates the running time. A call
-    typically costs hundreds of milliseconds and can exceed a second, so
-    prefer not to place it inside a loop or behind an interactive control
-    without lowering ``max_solutions`` first.
+    A call typically costs on the order of a hundred milliseconds and can
+    reach several seconds, so prefer not to place it inside a loop or behind
+    an interactive control without lowering ``max_solutions`` first. Cost
+    grows exponentially in the number of precision points, since the search
+    carries one free orientation per point after the first.
 
     Args:
         precision_points: List of (x, y) points the coupler should pass through.

--- a/tests/synthesis/test_path_generation_verification.py
+++ b/tests/synthesis/test_path_generation_verification.py
@@ -1,0 +1,110 @@
+"""The two verification back-ends must accept exactly the same solutions.
+
+``_verify_coupler_path`` simulates each candidate, which is the dominant cost of
+:func:`path_generation`. It runs through the numba solver where it can, and
+through ``Linkage.step()`` otherwise. The two report an unassemblable mechanism
+differently -- ``step()`` raises, the solver writes ``NaN`` -- so a naive switch
+silently changes which candidates survive.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from pylinkage.synthesis import path_generation
+
+# ``pylinkage.synthesis.path_generation`` is the re-exported *function*, so the
+# module has to come from the import system rather than attribute lookup.
+pg_module = importlib.import_module("pylinkage.synthesis.path_generation")
+
+# Point sets chosen to exercise different outcomes: plenty of solutions, few,
+# and a three-point problem that finishes early.
+POINT_SETS = {
+    "readme": [(0, 0), (1, 1), (2, 1), (3, 0)],
+    "documented": [(0.0, 1.0), (1.0, 2.0), (2.0, 1.5), (3.0, 0.0)],
+    "three_points": [(0, 0), (1.5, 1.2), (3, 0)],
+    "steep": [(0, 0), (0.5, 2.0), (1.0, 0.5), (2.0, 2.0)],
+}
+
+
+def solution_signature(result):
+    """Link lengths of every raw solution, order-independent."""
+    return sorted(
+        (
+            round(s.crank_length, 6),
+            round(s.coupler_length, 6),
+            round(s.rocker_length, 6),
+            round(s.ground_length, 6),
+        )
+        for s in result.raw_solutions
+    )
+
+
+@pytest.mark.parametrize("points", POINT_SETS.values(), ids=list(POINT_SETS))
+def test_numba_and_python_paths_agree(points, monkeypatch):
+    """Same solutions whether or not the numba solver is used."""
+    monkeypatch.setattr(pg_module, "HAS_NUMBA", False)
+    without_numba = path_generation(points)
+
+    monkeypatch.setattr(pg_module, "HAS_NUMBA", True)
+    with_numba = path_generation(points)
+
+    assert solution_signature(with_numba) == solution_signature(without_numba)
+
+
+@pytest.mark.parametrize("points", POINT_SETS.values(), ids=list(POINT_SETS))
+def test_solutions_pass_through_their_precision_points(points):
+    """Whatever survives verification must actually trace the path."""
+    result = path_generation(points)
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    diag = np.hypot(max(xs) - min(xs), max(ys) - min(ys))
+    tolerance = max(0.05 * diag, 0.01)
+
+    for solution in result.raw_solutions:
+        assert pg_module._verify_coupler_path(solution, points, tolerance=tolerance)
+
+
+class TestCouplerTrajectory:
+    """``_coupler_trajectory`` turns a simulation failure into None."""
+
+    def test_returns_one_row_per_iteration(self):
+        result = path_generation(POINT_SETS["readme"])
+        linkage = result.solutions[0]
+        trajectory = pg_module._coupler_trajectory(linkage, 50)
+        assert trajectory is not None
+        assert trajectory.shape == (50, 2)
+        assert np.isfinite(trajectory).all()
+
+    def test_nan_trajectory_is_rejected(self, monkeypatch):
+        """A NaN is how the solver reports what step() reports by raising.
+
+        Both mean the mechanism did not assemble at some crank angle, so both
+        have to reject the candidate.
+        """
+        result = path_generation(POINT_SETS["readme"])
+        linkage = result.solutions[0]
+
+        def nan_run(*args, **kwargs):
+            return np.full((10, len(linkage.components), 2), np.nan)
+
+        monkeypatch.setattr(pg_module, "HAS_NUMBA", True)
+        monkeypatch.setattr(type(linkage), "step_fast", nan_run)
+        assert pg_module._coupler_trajectory(linkage, 10) is None
+
+    def test_unsupported_component_falls_back_to_step(self, monkeypatch):
+        """A mechanism the solver cannot represent still gets verified."""
+        result = path_generation(POINT_SETS["readme"])
+        linkage = result.solutions[0]
+
+        def unsupported(*args, **kwargs):
+            raise NotImplementedError("PPDyad")
+
+        monkeypatch.setattr(pg_module, "HAS_NUMBA", True)
+        monkeypatch.setattr(type(linkage), "step_fast", unsupported)
+        trajectory = pg_module._coupler_trajectory(linkage, 20)
+        assert trajectory is not None
+        assert trajectory.shape == (20, 2)


### PR DESCRIPTION
Closes #29.

## Result

`path_generation()` is 2-8x faster with **identical** solutions.

| Precision points | Before | After | |
|---|---:|---:|---:|
| README example | 345 ms | 163 ms | 2.1x |
| Benchmarked example | 1689 ms | 678 ms | 2.5x |
| Three points | 430 ms | 55 ms | 7.8x |
| "Steep" | 2042 ms | 1054 ms | 1.9x |
| "Wide" | 1912 ms | 897 ms | 2.1x |

Solution counts are unchanged in every case.

## What changed

**Verification now runs through the numba solver.** `_verify_coupler_path` was 67% of the runtime, simulating each surviving candidate for 300 steps through the pure-Python `Linkage.step()`. It uses `step_fast()` now, which executes the same `solve_*` functions ~20x faster. This only became possible once #40 stopped `step_fast()` returning `NaN` for `FixedDyad` — the component carrying the coupler point.

**The rejection semantics needed care.** The two paths report an unassemblable mechanism differently: `step()` raises, and the caller reads that as "this candidate cannot complete a rotation"; `step_fast()` writes `NaN` instead. A naive swap silently changes which candidates survive — I hit exactly that while measuring for #40, where the two produced different sets of ten solutions. Both are now treated as rejection, and the accepted sets are asserted identical.

`step()` still runs when numba is absent, or when the mechanism holds a component the solver cannot represent.

**Two fixes in the simulation hot loop**, which speed up *every* simulation rather than only synthesis:

- `step()` re-ran `isinstance(component, (Crank, ArcCrank, LinearActuator))` for every component on every iteration, though whether a component is actuator-driven is a property of the solve order.
- `_get_anchor_position` ran an `isinstance` check against an abstract base class whose two branches returned the same expression.

`Linkage.step()` goes from 257,550 to 325,718 steps/s on the reference four-bar. The published `step_fast()` speedup therefore falls from 6.4x to **5.1x** — the numerator got faster, the solver did not regress. The page says so explicitly, so it does not read as a regression.

## On `n_orientation_samples` — measured, and left alone

#29 asked whether 36 is the right default and whether the parameter should be repaired. I implemented the honest version — the grid holding roughly `n_samples` candidates, as the name implies — and measured it:

| Point set | Current | Proposed |
|---|---|---|
| README | 168 ms, 10 solutions | 130 ms, 10 solutions |
| Benchmarked | 694 ms, 10 solutions | 209 ms, **0 solutions** |
| Three points | 55 ms, 6 solutions | 53 ms, 6 solutions |
| Steep | 1095 ms, 2 solutions | 205 ms, **0 solutions** |
| Wide | 925 ms, 10 solutions | 207 ms, **0 solutions** |

It loses solutions on half the cases, including the documented example dropping from ten to nothing. **The dense grid earns its cost.** Only the parameter's name and its documentation were ever wrong, and #41 already fixed those. No change to the search here.

## A limit nothing documented

Cost grows **exponentially in the number of precision points** — one free orientation per point after the first. Five points took **8 seconds and returned zero solutions**. The docstring's "best results with 3-5 points" undersells that considerably, so the benchmarks page now carries an explicit warning.

## Verification

- 11 new tests in `tests/synthesis/test_path_generation_verification.py`: numba and Python paths return identical solutions across four point sets, every returned solution genuinely passes through its precision points, NaN trajectories are rejected, and an unsupported component falls back to `step()`.
- Full suite 2488 passed, 5 skipped with all extras. Lint and `mypy --strict` clean on 134 files. Docs build clean.
- Benchmark figures regenerated with `benchmarks/run_benchmarks.py`; the hand-redacted environment table is untouched.

The page's `path_generation()` breakdown is rewritten, since the fix inverted it: Burmester synthesis over the orientation grid is now 87% of runtime and verification under 10%, where the page previously said 67% verification and 21% Burmester.

## Possible follow-up

`n_orientation_samples` remains badly named for what it does, and is now documented as a weak control rather than fixed. If you want it renamed or deprecated under the #22 policy, that is a small separate change — say the word and I will file it.